### PR TITLE
GH-209: Better focus managment in dialog after loaded

### DIFF
--- a/projects/storefrontlib/src/lib/cart/components/add-to-cart/added-to-cart-dialog/added-to-cart-dialog.component.html
+++ b/projects/storefrontlib/src/lib/cart/components/add-to-cart/added-to-cart-dialog/added-to-cart-dialog.component.html
@@ -1,4 +1,4 @@
-<div class="cx-added-to-cart-dialog">
+<div class="cx-added-to-cart-dialog" #dialog>
   <!-- Modal Header -->
   <ng-container *ngIf="loaded$ | async; else loading">
     <div class="cx-added-to-cart-dialog__header modal-header">
@@ -25,7 +25,7 @@
           </div>
           <!-- Actions -->
           <div class="cx-added-to-cart-dialog__actions">
-            <a routerLink="/cart" class="btn btn-primary" (click)="activeModal.dismiss('Cross click')">view cart</a>
+            <a routerLink="/cart" class="btn btn-primary" ngbAutoFocus (click)="activeModal.dismiss('Cross click')">view cart</a>
             <a routerLink="/checkout" class="btn btn-secondary" (click)="activeModal.dismiss('Cross click')">proceed to
               checkout</a>
           </div>

--- a/projects/storefrontlib/src/lib/cart/components/add-to-cart/added-to-cart-dialog/added-to-cart-dialog.component.spec.ts
+++ b/projects/storefrontlib/src/lib/cart/components/add-to-cart/added-to-cart-dialog/added-to-cart-dialog.component.spec.ts
@@ -1,4 +1,4 @@
-import { of } from 'rxjs';
+import { of, BehaviorSubject } from 'rxjs';
 import { CartService } from './../../../services/cart.service';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
@@ -68,6 +68,25 @@ describe('AddedToCartDialogComponent', () => {
         .nativeElement.textContent.trim()
     ).toEqual('Updating cart...');
     expect(el.query(By.css('cx-spinner')).nativeElement).toBeDefined();
+  });
+
+  it('should handle focus of elements', () => {
+    component.entry$ = of({
+      id: 111,
+      product: {
+        code: 'CODE1111'
+      }
+    });
+
+    const loaded$ = new BehaviorSubject<boolean>(false);
+    component.loaded$ = loaded$.asObservable();
+
+    fixture.detectChanges();
+    loaded$.next(true);
+    fixture.detectChanges();
+    expect(el.query(By.css('.btn-primary')).nativeElement).toEqual(
+      document.activeElement
+    );
   });
 
   it('should display quantity', () => {

--- a/projects/storefrontlib/src/lib/cart/components/add-to-cart/added-to-cart-dialog/added-to-cart-dialog.component.ts
+++ b/projects/storefrontlib/src/lib/cart/components/add-to-cart/added-to-cart-dialog/added-to-cart-dialog.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  AfterViewChecked,
+  ElementRef,
+  ViewChild
+} from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Observable } from 'rxjs';
 
@@ -7,13 +13,35 @@ import { Observable } from 'rxjs';
   templateUrl: './added-to-cart-dialog.component.html',
   styleUrls: ['./added-to-cart-dialog.component.scss']
 })
-export class AddedToCartDialogComponent implements OnInit {
+export class AddedToCartDialogComponent implements OnInit, AfterViewChecked {
   entry$: Observable<any>;
   cart$: Observable<any>;
   loaded$: Observable<boolean>;
   quantity = 0;
+  previousLoadedState;
+  finishedLoading;
+
+  @ViewChild('dialog', { read: ElementRef })
+  dialog: ElementRef;
 
   constructor(public activeModal: NgbActiveModal) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.loaded$.subscribe(res => {
+      if (this.previousLoadedState !== res) {
+        this.finishedLoading = this.previousLoadedState === false;
+        this.previousLoadedState = res;
+      }
+    });
+  }
+
+  ngAfterViewChecked() {
+    if (this.finishedLoading) {
+      this.finishedLoading = false;
+      const elementToFocus = this.dialog.nativeElement.querySelector(
+        `[ngbAutofocus]`
+      ) as HTMLElement;
+      elementToFocus.focus();
+    }
+  }
 }


### PR DESCRIPTION
After we load dialog content we move focus to the element with ngbAutoFocus attribute. I decided not to change styles for focused close button, because that should be first consulted from UX/Design perspective.

Closes #209 