### PR TITLE
GH-306: Fixedtest 'should redirect when clicking on order id'

### DIFF
--- a/projects/storefrontlib/src/lib/my-account/order/order-history/order-history.component.spec.ts
+++ b/projects/storefrontlib/src/lib/my-account/order/order-history/order-history.component.spec.ts
@@ -1,16 +1,18 @@
-import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { of, BehaviorSubject } from 'rxjs';
 import { By } from '@angular/platform-browser';
+
+import { RoutingService } from '@spartacus/core';
+
+import { of, BehaviorSubject } from 'rxjs';
+
 import createSpy = jasmine.createSpy;
 
-import { PaginationAndSortingModule } from '../../../ui/components/pagination-and-sorting/pagination-and-sorting.module';
-import { OrderHistoryComponent } from './order-history.component';
-
 import { AuthService } from '../../../auth/facade/auth.service';
-import { RoutingService } from '@spartacus/core';
 import { UserService } from '../../../user/facade/user.service';
+import { PaginationAndSortingModule } from '../../../ui/components/pagination-and-sorting/pagination-and-sorting.module';
+
+import { OrderHistoryComponent } from './order-history.component';
 
 const mockOrders = {
   orders: [
@@ -23,16 +25,13 @@ const mockOrders = {
 describe('OrderHistoryComponent', () => {
   let component: OrderHistoryComponent;
   let fixture: ComponentFixture<OrderHistoryComponent>;
-  let el: DebugElement;
 
   let mockAuthService: any;
   let mockRoutingService: any;
   let mockUserService: any;
 
   beforeEach(async(() => {
-    mockRoutingService = {
-      go: createSpy()
-    };
+    mockRoutingService = {};
     mockAuthService = {
       userToken$: of({ userId: 'test' })
     };
@@ -55,7 +54,6 @@ describe('OrderHistoryComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderHistoryComponent);
-    el = fixture.debugElement;
     component = fixture.componentInstance;
   });
 
@@ -99,16 +97,10 @@ describe('OrderHistoryComponent', () => {
     component.ngOnInit();
     fixture.detectChanges();
 
-    el.query(By.css('.cx-order-history__table tbody tr')).triggerEventHandler(
-      'click',
-      null
-    );
-    fixture.whenStable().then(() => {
-      expect(mockRoutingService.go).toHaveBeenCalledWith([
-        'my-account/orders/',
-        1
-      ]);
-    });
+    expect(
+      fixture.debugElement.query(By.css('.cx-order-history__code a')).properties
+        .href
+    ).toEqual(`/my-account/orders/${mockOrders.orders[0].code}`);
   });
 
   it('should display No orders found page if no orders are found', () => {
@@ -122,7 +114,9 @@ describe('OrderHistoryComponent', () => {
     component.ngOnInit();
     fixture.detectChanges();
 
-    expect(el.query(By.css('.cx-order-history__no-order'))).not.toBeNull();
+    expect(
+      fixture.debugElement.query(By.css('.cx-order-history__no-order'))
+    ).not.toBeNull();
   });
 
   it('should set correctly sort code', () => {


### PR DESCRIPTION
The original test used to actually click the selector and wait. The first problem was that the wrong selector was called. Also the way the test was working asynchronously was flawed. 

In my opinion, we shouldn't test the fact that it navigates because this is out of the scope of a unit test as we are testing the router. The fact that the element is an anchor tag and that the href is correct is good according to me.

Fixes: #306 