### PR TITLE
GH-718 avoid unnecessary call to OCC when leaving product details page

### DIFF
--- a/projects/storefrontlib/src/lib/ui/pages/product-page/product-page.component.html
+++ b/projects/storefrontlib/src/lib/ui/pages/product-page/product-page.component.html
@@ -1,7 +1,9 @@
 <div class="cx-page">
   <section class="cx-page__section">
-    <cx-product-details-page-layout
-      [productCode]="productCode"
-    ></cx-product-details-page-layout>
+    <ng-container *ngIf="productCode">
+      <cx-product-details-page-layout
+        [productCode]="productCode"
+      ></cx-product-details-page-layout>
+    </ng-container>
   </section>
 </div>

--- a/projects/storefrontlib/src/lib/ui/pages/product-page/product-page.component.spec.ts
+++ b/projects/storefrontlib/src/lib/ui/pages/product-page/product-page.component.spec.ts
@@ -6,6 +6,7 @@ import { RoutingService } from '@spartacus/core';
 import { of } from 'rxjs';
 
 import { ProductPageComponent } from './product-page.component';
+import { By } from '@angular/platform-browser';
 
 @Component({
   selector: 'cx-product-details-page-layout',
@@ -16,21 +17,10 @@ export class MockProductDetailsPageLayoutComponent {
   productCode: string;
 }
 
-const routerState = {
-  state: {
-    params: {
-      productCode: 'mockProductCode'
-    }
-  }
-};
-const mockRoutingService = {
-  getRouterState() {
-    return of(routerState);
-  }
-};
 describe('ProductPageComponent in pages', () => {
   let component: ProductPageComponent;
   let fixture: ComponentFixture<ProductPageComponent>;
+  let routingService: RoutingService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -38,21 +28,48 @@ describe('ProductPageComponent in pages', () => {
         ProductPageComponent,
         MockProductDetailsPageLayoutComponent
       ],
-      providers: [{ provide: RoutingService, useValue: mockRoutingService }]
+      providers: [
+        { provide: RoutingService, useValue: { getRouterState: () => {} } }
+      ]
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductPageComponent);
     component = fixture.componentInstance;
+    routingService = TestBed.get(RoutingService);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call ngOnInit', () => {
-    component.ngOnInit();
+  it('should get "productCode" from route parameters', () => {
+    spyOn(routingService, 'getRouterState').and.returnValue(
+      of({ state: { params: { productCode: 'mockProductCode' } } })
+    );
+    fixture.detectChanges();
     expect(component.productCode).toEqual('mockProductCode');
+  });
+
+  describe('product details page layout', () => {
+    const getProductDetailsLayout = () =>
+      fixture.debugElement.query(By.css('cx-product-details-page-layout'));
+
+    it('should be rendered when "productCode" is defined', () => {
+      spyOn(routingService, 'getRouterState').and.returnValue(
+        of({ state: { params: { productCode: 'mockProductCode' } } })
+      );
+      fixture.detectChanges();
+      expect(getProductDetailsLayout()).toBeTruthy();
+    });
+
+    it('should NOT be rendered when "productCode" is undefined', () => {
+      spyOn(routingService, 'getRouterState').and.returnValue(
+        of({ state: { params: { productCode: undefined } } })
+      );
+      fixture.detectChanges();
+      expect(getProductDetailsLayout()).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
# Introduction
Previously the container component subscibed to router state and passed `productCode` route param down the component tree. One of the child components was talking with OCC endpoint on every `productCode` change.

When leaving the product details page, router state already changed to `/cart`. But Product details page was still active for one change detection cycle. This caused passing down the components tree the undefined `productCode` route param.

# Changes
Child components wrapped in `*ngIf="productCode"`

Closes #718 