### PR TITLE
ci: Add protractor report as artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,8 @@ addons:
     organization: sap
     token:
       secure: I2+ah2XiEbJ6MwWG51B0Vqpsv7KhnqMJzhoPTun6iPxlMXVqIJm1bCRkutOtlVJ+65UDj20H6ld0Tc9LOEz3Uvjk/ZSmHIA/7esC1kRcOu62VE8k/Y+nH8epI3dBr70Yymn9V27kqBNTMs+i2qC8z/+2cd0DBrAPtRQXcPedd4kw41kdeFBzmI/ng1uOhadLF2U63s+krkfLSoaBcCkksll3KsnDe/ItJN1Hu7oZ5UQUxcbP8LHDHBIm3YuMDh9WLWvp9zypglS5as8GC55Zi8dDFlqXrcVcKa5niN8Q/UOByBDy1JiM6kJbc/mjbpjdQMAoCz9YjkPhd181hbz0rocxqPmbEszwPVNadRbz3mUjTz/us+3ekrw3/i4DhuzmGlV2kRkbXIquegecivNnWMP8JyZDRerR8onSKS+YMmEI1t7tOLWHCJ4ImkfMWGVbT8t27ZWO2bhDu+N0JxyPuMRSVPRXvhEAqIbts8OdeITxQiWcSdI2Q/Fsfsft7uUBJhhU8S+c6Gs0LuCikG4WfchjCUxK5kFQqEAqLX+BUJbQxw6J2S+geoAzxWhQrs+O/GzXDzuez8Z3Ou8hk2w/l+VSJ2MuiJq/jlcSmVkYUUtKhvPfq/fcLtp9Lt9dUCw/8Es9jbvtg/0i2iyajkF/9PRc6UzhcYu/sk8xopNK4bQ=
+  artifacts:
+    paths:
+      - protractor.log.json
+    target_paths:
+      - /$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/$TRAVIS_COMMIT/

--- a/projects/storefrontapp-e2e/protractor.headless.conf.js
+++ b/projects/storefrontapp-e2e/protractor.headless.conf.js
@@ -20,6 +20,7 @@ exports.config = {
       ]
     }
   },
+  resultJsonOutputFile: 'protractor.log.json',
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,


### PR DESCRIPTION
**How it works:**
- protractor can output nice json with each test, description, and status (for errors additionally error message and stacktrace)
- travis can upload any specified file in artifacts section of the config to S3 bucket. Already created one and set necessary environmental variables in travis

**Why:**
- after some time we will have results for each e2e test run. With these, we can analyze the failure ration correctly (we have logs grouped by branch and commit hash) So when we have multiple logs per commit and one of them passes everything that means it was because of flaky test. Failures for develop branch would probably also count as flaky.
- with these logs we can find specific tests that cause the most failures and improve them one by one

**Limitations:**
- it works only for push action on travis (pr builds does not send artifacts) - we would only get result for those. Failure rate should be similar on both types (logic suggest that).
- implementing protractor retry should take this into account. It should then output multiple logs. Each for a separate run and upload all of them to S3