### PR TITLE
GH-979: Fixing broken links in various install docs

### DIFF
--- a/docs/archive/1808/contributorsetup.md
+++ b/docs/archive/1808/contributorsetup.md
@@ -17,22 +17,12 @@ Your Angular development environment should include the following:
 
 ## Back end Requirements
 
-The Spartacus JavaScript Storefront uses SAP Commerce for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
+The Spartacus JavaScript Storefront uses SAP Commerce Cloud for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
 
-Perform the following steps to set up your back end:
+To install SAP Commerce Cloud, refer to the 1808 [installation instructions](../../../back_end_installation).
 
-- Install a new instance of SAP Commerce 1808 using the `b2c_acc_plus` recipe, as follows:
+Note: The latest release of SAP Commerce Cloud is recommended.
 
-   1. In the `installer` folder of SAP Commerce 1808, make a copy of `b2c_acc_plus` and call it `b2c_for_spartacus`.
-
-   2. Delete the existing `build.gradle` file in the `b2c_for_spartacus` recipe folder. 
-
-   3. Add this [build.gradle](assets/build.gradle) file to your `b2c_for_spartacus` recipe folder.
-
-   4. Follow the instructions in https://help.hybris.com/1808/hcd/8c46c266866910149666a0fe4caeee4e.html to install, intialize and start a new instance of SAP Commerce 1808, using `b2c_for_spartacus` as the recipe name.
-
-- Import `spartacus_sample_data.impex`, which you can download here: https://help.hybris.com/1808/api/spartacus/spartacus_sample_data.impex
-- Configure your OCC client, as described here: https://help.hybris.com/1808/hcd/627c92db29ce4fce8b01ffbe478a8b3b.html#loio4079b4327ac243b6b3bd507cda6d74ff
 
 # Cloning the Sources
 

--- a/docs/archive/1808/contributorsetup.md
+++ b/docs/archive/1808/contributorsetup.md
@@ -19,7 +19,7 @@ Your Angular development environment should include the following:
 
 The Spartacus JavaScript Storefront uses SAP Commerce Cloud for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
 
-To install SAP Commerce Cloud, refer to the 1808 [installation instructions](../../../back_end_installation).
+To install SAP Commerce Cloud, refer to the 1808 [installation instructions](../../back_end_installation).
 
 Note: The latest release of SAP Commerce Cloud is recommended.
 

--- a/docs/archive/1808/setupandinstallation.md
+++ b/docs/archive/1808/setupandinstallation.md
@@ -18,25 +18,11 @@ Your Angular development environment should include the following:
 
 ## Back end Requirements
 
-The Spartacus JavaScript Storefront uses SAP Commerce for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
+The Spartacus JavaScript Storefront uses SAP Commerce Cloud for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
 
-Perform the following steps to set up your back end:
+To install SAP Commerce Cloud, refer to the 1808 [installation instructions](../../../back_end_installation).
 
-- Install a new instance of SAP Commerce 1808 using the `b2c_acc_plus` recipe, as follows:
-
-   1. In the `installer/recipes` folder of SAP Commerce 1808, make a copy of `b2c_acc_plus` and call it `b2c_for_spartacus`.
-
-   2. Delete the existing `build.gradle` file in the `b2c_for_spartacus` recipe folder. 
-
-   3. Add this [build.gradle](assets/build.gradle) file to your `b2c_for_spartacus` recipe folder.
-
-   4. Follow the instructions in https://help.hybris.com/1808/hcd/8c46c266866910149666a0fe4caeee4e.html to install, initialize and start a new instance of SAP Commerce 1808, using `b2c_for_spartacus` as the recipe name.
-
-- Import `spartacus_sample_data.impex`, which you can download here: https://help.hybris.com/1808/api/spartacus/spartacus_sample_data.impex
-
-  For more information on importing ImpEx, see https://help.hybris.com/1808/hcd/2f095d195c0740aab4b0bbdf0f0a2d12.html. 
-
-- Configure your OCC client, as described here: https://help.hybris.com/1808/hcd/627c92db29ce4fce8b01ffbe478a8b3b.html#loio4079b4327ac243b6b3bd507cda6d74ff
+Note: The latest release of SAP Commerce Cloud is recommended.
 
 # Creating a New Angular Application
 

--- a/docs/archive/1808/setupandinstallation.md
+++ b/docs/archive/1808/setupandinstallation.md
@@ -20,7 +20,7 @@ Your Angular development environment should include the following:
 
 The Spartacus JavaScript Storefront uses SAP Commerce Cloud for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
 
-To install SAP Commerce Cloud, refer to the 1808 [installation instructions](../../../back_end_installation).
+To install SAP Commerce Cloud, refer to the 1808 [installation instructions](../../back_end_installation).
 
 Note: The latest release of SAP Commerce Cloud is recommended.
 

--- a/docs/back_end_installation/1808/back_end_installation.md
+++ b/docs/back_end_installation/1808/back_end_installation.md
@@ -10,7 +10,7 @@ Perform the following steps to set up your back end:
 
    2. Delete the existing `build.gradle` file in the `b2c_for_spartacus` recipe folder. 
 
-   3. Add this [build.gradle](docs/back_end_installation/1808/build.gradle) file to your `b2c_for_spartacus` recipe folder.
+   3. Add this [build.gradle](build.gradle) file to your `b2c_for_spartacus` recipe folder.
 
    4. Follow the instructions in https://help.hybris.com/1808/hcd/8c46c266866910149666a0fe4caeee4e.html to install, initialize and start a new instance of SAP Commerce 1808, using `b2c_for_spartacus` as the recipe name.
 

--- a/docs/back_end_installation/1811/back_end_installation.md
+++ b/docs/back_end_installation/1811/back_end_installation.md
@@ -10,7 +10,7 @@ Perform the following steps to set up your back end:
 
    2. Delete the existing `build.gradle` file in the `b2c_for_spartacus` recipe folder. 
 
-   3. Add this [build.gradle](docs/back_end_installation/1811/build.gradle) file to your `b2c_for_spartacus` recipe folder.
+   3. Add this [build.gradle](build.gradle) file to your `b2c_for_spartacus` recipe folder.
 
    4. Follow the instructions in https://help.hybris.com/1811/hcd/8c46c266866910149666a0fe4caeee4e.html to install, initialize and start a new instance of SAP Commerce 1811, using `b2c_for_spartacus` as the recipe name.
 

--- a/docs/contributorsetup.md
+++ b/docs/contributorsetup.md
@@ -19,7 +19,7 @@ Your Angular development environment should include the following:
 
 The Spartacus JavaScript Storefront uses SAP Commerce Cloud for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
 
-To install SAP Commerce Cloud, refer to the [installation instructions](docs/back_end_installation) appropriate to your version.
+To install SAP Commerce Cloud, refer to the [installation instructions](back_end_installation) appropriate to your version.
 
 Note: The latest release of SAP Commerce Cloud is recommended.
 
@@ -103,7 +103,7 @@ $ yarn start:prod
 
 In both development mode and production mode, the Spartacus storefront has default values for all of its configurations. However, you may need to override these values.
 
-To configure the storfront, use the `withConfig` method on the StorefrontModule. The following is an example:
+To configure the storefront, use the `withConfig` method on the StorefrontModule. The following is an example:
 
 ```
 @NgModule({

--- a/docs/setupandinstallation.md
+++ b/docs/setupandinstallation.md
@@ -20,7 +20,7 @@ Your Angular development environment should include the following:
 
 The Spartacus JavaScript Storefront uses SAP Commerce Cloud for its back end, and makes use of the sample data from the B2C Accelerator electronics storefront in particular.
 
-To install SAP Commerce Cloud, refer to the [installation instructions](docs/back_end_installation) appropriate to your version.
+To install SAP Commerce Cloud, refer to the [installation instructions](back_end_installation) appropriate to your version.
 
 Note: The latest release of SAP Commerce Cloud is recommended.
 


### PR DESCRIPTION
Need to fix a bunch of broken links in

* setupandinstallation.md
* contributorsetup.md
* 1808/back_end_installation.md
* 1811/back_end_installation.md
* archive/1808/setupandinstallation.md
* archive/1808/contributorsetup.md