### PR TITLE
feat(@spartacus/storefront): add outlets to page layouts

### DIFF
--- a/projects/storefrontlib/src/lib/cms/page-layout/page-layout.component.html
+++ b/projects/storefrontlib/src/lib/cms/page-layout/page-layout.component.html
@@ -1,5 +1,7 @@
-<ng-content></ng-content>
-<cx-dynamic-slot
-  *ngFor="let slot of (slots$ | async)"
-  [position]="slot"
-></cx-dynamic-slot>
+<ng-container *cxOutlet="section || (templateName$ | async)">
+  <ng-content></ng-content>
+  <cx-dynamic-slot
+    *ngFor="let slot of (slots$ | async)"
+    [position]="slot"
+  ></cx-dynamic-slot>
+</ng-container>

--- a/projects/storefrontlib/src/lib/cms/page-layout/page-layout.module.ts
+++ b/projects/storefrontlib/src/lib/cms/page-layout/page-layout.module.ts
@@ -2,9 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PageLayoutComponent } from './page-layout.component';
 import { CmsModule } from '../cms.module';
+import { OutletModule } from '../../outlet';
 
 @NgModule({
-  imports: [CommonModule, CmsModule],
+  imports: [CommonModule, CmsModule, OutletModule],
   declarations: [PageLayoutComponent],
   exports: [PageLayoutComponent]
 })


### PR DESCRIPTION
When page layouts are rendered we add an outlet for either the section or page template. This allows to customise (replace, or append) a page template or a section (i.e. header)

closes #989 