### PR TITLE
fix(@spartacus/core): accept empty string URL to be recognized and translated

### DIFF
--- a/projects/core/src/routing/configurable-routes/url-translation/url-translation.service.spec.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url-translation.service.spec.ts
@@ -115,30 +115,6 @@ describe('UrlTranslationService', () => {
       });
     });
 
-    describe(`, when options 'url' property is empty string,`, () => {
-      let options: TranslateUrlOptions;
-      beforeEach(() => {
-        spyOn(console, 'warn');
-        options = { url: '' };
-      });
-
-      it(`should console.warn in non-production environment`, () => {
-        serverConfig.production = false;
-        service.translate(options);
-        expect(console.warn).toHaveBeenCalled();
-      });
-
-      it(`should NOT console.warn in production environment`, () => {
-        serverConfig.production = true;
-        service.translate(options);
-        expect(console.warn).not.toHaveBeenCalled();
-      });
-
-      it(`should return the root url`, () => {
-        expect(service.translate(options)).toEqual(['/']);
-      });
-    });
-
     describe(`, when options 'url' property is null,`, () => {
       let options: TranslateUrlOptions;
       beforeEach(() => {
@@ -191,7 +167,7 @@ describe('UrlTranslationService', () => {
       let options: TranslateUrlOptions;
       beforeEach(() => {
         spyOn(console, 'warn');
-        options = { url: '' };
+        options = { route: null };
       });
 
       it(`should console.warn in non-production environment`, () => {
@@ -232,6 +208,17 @@ describe('UrlTranslationService', () => {
 
       it(`should return the root url`, () => {
         expect(service.translate(options)).toEqual(['/']);
+      });
+    });
+
+    describe(`, when options 'url' property is empty string,`, () => {
+      it('should try to recognize nested routes names in given url', () => {
+        spyOn(routesService, 'getNestedRoutesTranslations').and.returnValue(
+          null
+        );
+        spyOn(routeRecognizer, 'recognizeByDefaultUrl').and.returnValue(null);
+        service.translate({ url: '' });
+        expect(routeRecognizer.recognizeByDefaultUrl).toHaveBeenCalledWith('');
       });
     });
 

--- a/projects/core/src/routing/configurable-routes/url-translation/url-translation.service.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url-translation.service.ts
@@ -47,11 +47,11 @@ export class UrlTranslationService {
       return false;
     }
 
-    const urlDefined = options.url || options.url === '';
-    const routeDefined = Array.isArray(options.route);
+    const urlDefined = Boolean(options.url) || options.url === '';
+    const routeDefined = Boolean(options.route);
     if (!urlDefined && !routeDefined) {
       this.warn(
-        `Incorrect options for translating url. Options must have 'url' or 'route' property. Options: `,
+        `Incorrect options for translating url. Options must have 'url' string or 'route' array property. Options: `,
         options
       );
       return false;
@@ -87,6 +87,15 @@ export class UrlTranslationService {
   private validateOptionsRoute(
     nestedRoutes: TranslateUrlOptionsRoute[]
   ): boolean {
+    if (!Array.isArray(nestedRoutes)) {
+      this.warn(
+        `Incorrect options for translating url.`,
+        `'route' property should be an array. Route: `,
+        nestedRoutes
+      );
+      return false;
+    }
+
     const length = nestedRoutes.length;
     if (!length) {
       this.warn(

--- a/projects/core/src/routing/configurable-routes/url-translation/url-translation.service.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url-translation.service.ts
@@ -28,7 +28,7 @@ export class UrlTranslationService {
       return this.ROOT_URL;
     }
 
-    if (options.url) {
+    if (typeof options.url === 'string') {
       const recognizedRoute = this.routeRecognizer.recognizeByDefaultUrl(
         options.url
       );
@@ -46,34 +46,37 @@ export class UrlTranslationService {
       );
       return false;
     }
-    if (!options.url && !options.route) {
+
+    const urlDefined = options.url || options.url === '';
+    const routeDefined = Array.isArray(options.route);
+    if (!urlDefined && !routeDefined) {
       this.warn(
         `Incorrect options for translating url. Options must have 'url' or 'route' property. Options: `,
         options
       );
       return false;
     }
-    if (options.url && options.route) {
+    if (urlDefined && routeDefined) {
       this.warn(
         `Incorrect options for translating url. Options cannot have both 'url' and 'route' property. Options: `,
         options
       );
       return false;
     }
-    if (options.url) {
+    if (urlDefined) {
       return this.validateOptionsUrl(options.url);
     }
-    if (options.route) {
+    if (routeDefined) {
       return this.validateOptionsRoute(options.route);
     }
     return true;
   }
 
   private validateOptionsUrl(url: string): boolean {
-    if (!url || typeof url !== 'string') {
+    if (typeof url !== 'string') {
       this.warn(
         `Incorrect options for translating url.`,
-        `'url' property should be a non-empty string. Url: `,
+        `'url' property should be a string. Url: `,
         url
       );
       return false;


### PR DESCRIPTION
Previously, when empty string came from CMS data as an URL (for example to home page), then it couldn't be translated due to validation which was rejecting empty string. Now validation allows empty string.

Additionaly, the typo in unit tests was fixed (line 170).

fixes GH-985