### PR TITLE
feat(@spartacus/storefront): allow for different page heading and titles in meta resolvers

### DIFF
--- a/docs/architecture/seo.md
+++ b/docs/architecture/seo.md
@@ -60,11 +60,17 @@ Spartacus is shipped with `pageMetaResolvers` which resolves the page meta data 
 
 The page meta will be updated dynamically during navigation, but can be delivered statically using SSR.
 
-### Title tag
+### Title resolver
 Adding an html page title has several advantages:
 * the page can be uniquely addressed in the browser (browser history, bookmarks, tabs, etc)
 * the page title will increase ranking the page in search engines
 * the page title will identify content in search engines
 
-### Description tag
+A special resolver is provided for pages that require a specific heading. The page title for a Search Engine Result Page (SERP) is not necessary the same as the page heading shown in the UI. The product title is a good example. For a great SERP, a pdp would typically disclose the product title, category and brand:
+
+`Product Title | Main category | Brand`
+
+Such a title however will look bad in the UI and a very different title is used for that. In order to support flexibility, Spartacus uses a specific `PageHeadingResolver` that can be implemented in the page resolving logic. 
+
+### Description resolver
 Each page on the storefront can contain a so-called description tag. The description tag is used at the SERP (search engine result page) to improve the click-through-rate (CTR). It is not used to improve page ranking. It is generally considered best practice to create a description tag for each page, although there are occassion where the search engine is better capable to generate the description based on the context.

--- a/projects/core/src/cms/model/page.model.ts
+++ b/projects/core/src/cms/model/page.model.ts
@@ -14,5 +14,6 @@ export interface Page {
 
 export interface PageMeta {
   title?: string;
+  heading?: string;
   description?: string;
 }

--- a/projects/core/src/cms/page/page.resolvers.ts
+++ b/projects/core/src/cms/page/page.resolvers.ts
@@ -1,7 +1,11 @@
-export type PageTitleResolver = {
-  resolveTitle(...args);
-};
+export interface PageHeadingResolver {
+  resolveHeading(...args);
+}
 
-export type PageDescriptionResolver = {
+export interface PageTitleResolver {
+  resolveTitle(...args);
+}
+
+export interface PageDescriptionResolver {
   resolveDescription(...args);
-};
+}

--- a/projects/core/src/product/services/product-page-meta.resolver.spec.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { PageType } from '../../occ/occ-models/occ.models';
+import { PageType, Product } from '../../occ/occ-models/occ.models';
 import { Observable, of } from 'rxjs';
 import {
   Page,
@@ -39,10 +39,16 @@ class MockRoutingService {
 
 class MockProductService {
   get(code: string) {
-    return of({
+    return of(<Product>{
       code: code,
       name: 'Product title',
-      summary: 'Product summary'
+      summary: 'Product summary',
+      categories: [
+        {
+          code: '123'
+        }
+      ],
+      manufacturer: 'Canon'
     });
   }
 }
@@ -76,6 +82,18 @@ describe('ProductPageTitleResolver', () => {
     }
   ));
 
+  it('should resolve product page heading', () => {
+    let result: PageMeta;
+    service
+      .getMeta()
+      .subscribe(value => {
+        result = value;
+      })
+      .unsubscribe();
+
+    expect(result.heading).toEqual('Product title');
+  });
+
   it('should resolve product page title', () => {
     let result: PageMeta;
     service
@@ -85,7 +103,7 @@ describe('ProductPageTitleResolver', () => {
       })
       .unsubscribe();
 
-    expect(result.title).toEqual('Product title');
+    expect(result.title).toEqual('Product title | 123 | Canon');
   });
 
   it('should have product description', () => {

--- a/projects/core/src/product/services/product-page-meta.resolver.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.ts
@@ -8,14 +8,15 @@ import { PageMetaResolver } from '../../cms/page/page-meta.resolver';
 import { PageMeta } from '../../cms/model/page.model';
 import {
   PageTitleResolver,
-  PageDescriptionResolver
+  PageDescriptionResolver,
+  PageHeadingResolver
 } from '../../cms/page/page.resolvers';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ProductPageMetaResolver extends PageMetaResolver
-  implements PageTitleResolver, PageDescriptionResolver {
+  implements PageHeadingResolver, PageTitleResolver, PageDescriptionResolver {
   constructor(
     protected routingService: RoutingService,
     protected productService: ProductService
@@ -33,6 +34,7 @@ export class ProductPageMetaResolver extends PageMetaResolver
           filter(Boolean),
           map((p: Product) => {
             return {
+              heading: this.resolveHeading(p),
               title: this.resolveTitle(p),
               description: this.resolveDescription(p)
             };
@@ -42,11 +44,29 @@ export class ProductPageMetaResolver extends PageMetaResolver
     );
   }
 
-  resolveTitle(product: Product) {
+  resolveHeading(product: Product): string {
     return product.name;
   }
 
-  resolveDescription(product: Product) {
+  resolveTitle(product: Product): string {
+    let title = product.name;
+    title += this.resolveFirstCategory(product);
+    title += this.resolveManufactorer(product);
+
+    return title;
+  }
+
+  resolveDescription(product: Product): string {
     return product.summary;
+  }
+
+  private resolveFirstCategory(product: Product): string {
+    return product.categories && product.categories.length > 0
+      ? ` | ${product.categories[0].code}`
+      : '';
+  }
+
+  private resolveManufactorer(product: Product): string {
+    return product.manufacturer ? ` | ${product.manufacturer}` : '';
   }
 }

--- a/projects/storefrontlib/src/lib/cms-lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/storefrontlib/src/lib/cms-lib/breadcrumb/breadcrumb.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { CmsBreadcrumbsComponent } from '@spartacus/core';
+import { CmsBreadcrumbsComponent, PageMeta } from '@spartacus/core';
 import { CmsComponentData } from './../../cms/components/cms-component-data';
 
 import { PageMetaService } from '@spartacus/core';
@@ -21,7 +21,7 @@ export class BreadcrumbComponent {
   get title$(): Observable<string> {
     return this.pageMetaService.getMeta().pipe(
       filter(Boolean),
-      map(meta => meta.title)
+      map((meta: PageMeta) => meta.heading || meta.title)
     );
   }
 


### PR DESCRIPTION
The page title for the SERP is not necessary the same as the page heading shown in the UI. This PR provides a dedicated page heading resolver to differentiate the two.

closes #1528 