### PR TITLE
feat(core): move flexType mapping logic to effects

### DIFF
--- a/projects/core/src/cms/store/effects/page.effect.spec.ts
+++ b/projects/core/src/cms/store/effects/page.effect.spec.ts
@@ -100,14 +100,12 @@ describe('Page Effects', () => {
       uid: 'comp1',
       typeCode: 'SimpleBannerComponent',
       uuid: 'compUuid1',
-      catalogUuid: undefined,
-      flexType: undefined
+      flexType: 'SimpleBannerComponent'
     },
     {
       uid: 'comp2',
       typeCode: 'CMSFlexComponent',
       uuid: 'compUuid2',
-      catalogUuid: undefined,
       flexType: 'AccountAddressBookComponent'
     }
   ];

--- a/projects/core/src/cms/store/effects/page.effect.ts
+++ b/projects/core/src/cms/store/effects/page.effect.ts
@@ -115,7 +115,7 @@ export class PageEffects {
     };
 
     if (component.catalogUuid) {
-      comp.catalogUuid = component.catalogUuid;
+      comp.catalogUuid = this.getCatalogUuid(component);
     }
     if (component.flexType) {
       comp.flexType = component.flexType;

--- a/projects/core/src/cms/store/effects/page.effect.ts
+++ b/projects/core/src/cms/store/effects/page.effect.ts
@@ -22,6 +22,8 @@ import { RoutingService } from '../../../routing/index';
 import { CMSPage, CmsComponent } from '../../../occ/occ-models/index';
 import { LOGIN, LOGOUT } from '../../../auth/store/actions/login-logout.action';
 import { LANGUAGE_CHANGE } from '../../../site-context/store/actions/languages.action';
+import { JSP_INCLUDE_CMS_COMPONENT_TYPE } from '../../config/cms-config';
+import { ContentSlotComponentData } from '../../model/content-slot-component-data.model';
 
 @Injectable()
 export class PageEffects {
@@ -93,18 +95,36 @@ export class PageEffects {
         Array.isArray(slot.components.component)
       ) {
         for (const component of slot.components.component) {
-          page.slots[slot.position].components.push({
-            uid: component.uid,
-            uuid: component.uuid,
-            catalogUuid: this.getCatalogUuid(component),
-            typeCode: component.typeCode,
-            flexType: component.flexType
-          });
+          page.slots[slot.position].components.push(
+            this.getComponentData(component)
+          );
         }
       }
     }
 
     return page;
+  }
+
+  private getComponentData(
+    component: ContentSlotComponentData
+  ): ContentSlotComponentData {
+    const comp: ContentSlotComponentData = {
+      uid: component.uid,
+      uuid: component.uuid,
+      typeCode: component.typeCode
+    };
+
+    if (component.catalogUuid) {
+      comp.catalogUuid = component.catalogUuid;
+    }
+    if (component.flexType) {
+      comp.flexType = component.flexType;
+    } else if (component.typeCode === JSP_INCLUDE_CMS_COMPONENT_TYPE) {
+      comp.flexType = JSP_INCLUDE_CMS_COMPONENT_TYPE;
+    } else {
+      comp.flexType = component.typeCode;
+    }
+    return comp;
   }
 
   private getCatalogUuid(cmsItem: any): string {

--- a/projects/core/src/cms/store/effects/page.effect.ts
+++ b/projects/core/src/cms/store/effects/page.effect.ts
@@ -22,7 +22,10 @@ import { RoutingService } from '../../../routing/index';
 import { CMSPage, CmsComponent } from '../../../occ/occ-models/index';
 import { LOGIN, LOGOUT } from '../../../auth/store/actions/login-logout.action';
 import { LANGUAGE_CHANGE } from '../../../site-context/store/actions/languages.action';
-import { JSP_INCLUDE_CMS_COMPONENT_TYPE } from '../../config/cms-config';
+import {
+  JSP_INCLUDE_CMS_COMPONENT_TYPE,
+  CMS_FLEX_COMPONENT_TYPE
+} from '../../config/cms-config';
 import { ContentSlotComponentData } from '../../model/content-slot-component-data.model';
 
 @Injectable()
@@ -117,10 +120,10 @@ export class PageEffects {
     if (component.catalogUuid) {
       comp.catalogUuid = this.getCatalogUuid(component);
     }
-    if (component.flexType) {
+    if (component.typeCode === CMS_FLEX_COMPONENT_TYPE) {
       comp.flexType = component.flexType;
     } else if (component.typeCode === JSP_INCLUDE_CMS_COMPONENT_TYPE) {
-      comp.flexType = JSP_INCLUDE_CMS_COMPONENT_TYPE;
+      comp.flexType = component.uid;
     } else {
       comp.flexType = component.typeCode;
     }

--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.spec.ts
@@ -13,7 +13,8 @@ import {
   CmsService,
   ComponentMapperService,
   CmsConfig,
-  CxApiService
+  CxApiService,
+  ContentSlotComponentData
 } from '@spartacus/core';
 
 const testText = 'test text';
@@ -61,11 +62,17 @@ class MockCmsService {
 
 @Component({
   template:
-    '<ng-container cxComponentWrapper componentType="cms_typeCode" componentMappedType="CMSTestComponent" ' +
-    'componentUid="test_uid" componentUuid="test_uuid" componentCatalogUuid="test_catalogUuid">' +
-    '</ng-container>'
+    '<ng-container [cxComponentWrapper]="component">' + '</ng-container>'
 })
-class TestWrapperComponent {}
+class TestWrapperComponent {
+  component: ContentSlotComponentData = {
+    typeCode: 'cms_typeCode',
+    flexType: 'CMSTestComponent',
+    uid: 'test_uid',
+    uuid: 'test_uuid',
+    catalogUuid: 'test_catalogUuid'
+  };
+}
 
 describe('ComponentWrapperDirective', () => {
   let fixture: ComponentFixture<TestWrapperComponent>;

--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
@@ -28,8 +28,6 @@ import { isPlatformServer } from '@angular/common';
 export class ComponentWrapperDirective implements OnInit, OnDestroy {
   @Input() cxComponentWrapper: ContentSlotComponentData;
 
-  @Input() componentMappedType: string;
-
   cmpRef: ComponentRef<any>;
   webElement: any;
 
@@ -49,7 +47,7 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
       return;
     }
 
-    if (this.componentMapper.isWebComponent(this.componentMappedType)) {
+    if (this.componentMapper.isWebComponent(this.cxComponentWrapper.flexType)) {
       this.launchWebComponent();
     } else {
       this.launchComponent();
@@ -59,14 +57,14 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
   private shouldRenderComponent(): boolean {
     const isSSR = isPlatformServer(this.platformId);
     const isComponentDisabledInSSR = (
-      this.config.cmsComponents[this.componentMappedType] || {}
+      this.config.cmsComponents[this.cxComponentWrapper.flexType] || {}
     ).disableSSR;
     return !(isSSR && isComponentDisabledInSSR);
   }
 
   private launchComponent() {
     const factory = this.componentMapper.getComponentFactoryByCode(
-      this.componentMappedType
+      this.cxComponentWrapper.flexType
     );
 
     if (factory) {
@@ -86,7 +84,7 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
 
   private async launchWebComponent() {
     const elementName = await this.componentMapper.initWebComponent(
-      this.componentMappedType,
+      this.cxComponentWrapper.flexType,
       this.renderer
     );
 
@@ -116,8 +114,8 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
 
   private getInjectorForComponent(): Injector {
     const configProviders =
-      (this.config.cmsComponents[this.componentMappedType] || {}).providers ||
-      [];
+      (this.config.cmsComponents[this.cxComponentWrapper.flexType] || {})
+        .providers || [];
     return Injector.create({
       providers: [
         {

--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
@@ -16,7 +16,8 @@ import {
   CmsConfig,
   CmsService,
   ComponentMapperService,
-  CxApiService
+  CxApiService,
+  ContentSlotComponentData
 } from '@spartacus/core';
 import { CmsComponentData } from '../model/cms-component-data';
 import { isPlatformServer } from '@angular/common';
@@ -25,11 +26,9 @@ import { isPlatformServer } from '@angular/common';
   selector: '[cxComponentWrapper]'
 })
 export class ComponentWrapperDirective implements OnInit, OnDestroy {
-  @Input() componentType: string;
+  @Input() cxComponentWrapper: ContentSlotComponentData;
+
   @Input() componentMappedType: string;
-  @Input() componentUid: string;
-  @Input() componentUuid: string;
-  @Input() componentCatalogUuid: string;
 
   cmpRef: ComponentRef<any>;
   webElement: any;
@@ -110,8 +109,8 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
     T
   > {
     return {
-      uid: this.componentUid,
-      data$: this.cmsService.getComponentData(this.componentUid)
+      uid: this.cxComponentWrapper.uid,
+      data$: this.cmsService.getComponentData(this.cxComponentWrapper.uid)
     };
   }
 
@@ -136,22 +135,22 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
     this.renderer.setAttribute(
       element,
       'data-smartedit-component-id',
-      this.componentUid
+      this.cxComponentWrapper.uid
     );
     this.renderer.setAttribute(
       element,
       'data-smartedit-component-type',
-      this.componentType
+      this.cxComponentWrapper.typeCode
     );
     this.renderer.setAttribute(
       element,
       'data-smartedit-catalog-version-uuid',
-      this.componentCatalogUuid
+      this.cxComponentWrapper.catalogUuid
     );
     this.renderer.setAttribute(
       element,
       'data-smartedit-component-uuid',
-      this.componentUuid
+      this.cxComponentWrapper.uuid
     );
   }
 

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.html
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.html
@@ -1,9 +1,8 @@
 <ng-container *cxOutlet="position">
   <ng-container *ngFor="let component of (components$ | async)">
     <ng-container
-      *cxOutlet="getComponentMappedType(component)"
+      *cxOutlet="component.flexType"
       [cxComponentWrapper]="component"
-      [componentMappedType]="getComponentMappedType(component)"
     >
     </ng-container>
   </ng-container>

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.html
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.html
@@ -2,12 +2,8 @@
   <ng-container *ngFor="let component of (components$ | async)">
     <ng-container
       *cxOutlet="getComponentMappedType(component)"
-      cxComponentWrapper
-      [componentType]="component.typeCode"
+      [cxComponentWrapper]="component"
       [componentMappedType]="getComponentMappedType(component)"
-      [componentUid]="component.uid"
-      [componentUuid]="component.uuid"
-      [componentCatalogUuid]="component.catalogUuid"
     >
     </ng-container>
   </ng-container>

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
@@ -87,34 +87,4 @@ describe('PageSlotComponent', () => {
     expect(native.classList.contains('smartEditComponent')).toBeFalsy();
     expect(native.getAttribute('data-smartedit-component-id')).toEqual(null);
   });
-
-  describe('getComponentMappedType', () => {
-    let component: ContentSlotComponentData;
-
-    beforeEach(() => {
-      component = { uid: 'testUid' };
-    });
-
-    it('should return "uid" of the component when component type is "JspIncludeComponent"', () => {
-      component.typeCode = 'JspIncludeComponent';
-      expect(pageSlotComponent.getComponentMappedType(component)).toBe(
-        'testUid'
-      );
-    });
-
-    it('should return "flexType" of the component when component type is "CMSFlexComponent"', () => {
-      component.typeCode = 'CMSFlexComponent';
-      component.flexType = 'testComponentMappedType';
-      expect(pageSlotComponent.getComponentMappedType(component)).toBe(
-        'testComponentMappedType'
-      );
-    });
-
-    it('should return component type when it is NOT "JspIncludeComponent" nor "CMSFlexComponent"', () => {
-      component.typeCode = 'testComponentType';
-      expect(pageSlotComponent.getComponentMappedType(component)).toBe(
-        'testComponentType'
-      );
-    });
-  });
 });

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
@@ -1,9 +1,5 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import {
-  CmsService,
-  ContentSlotData,
-  ContentSlotComponentData
-} from '@spartacus/core';
+import { CmsService, ContentSlotData } from '@spartacus/core';
 import { of, Observable } from 'rxjs';
 
 import { PageSlotComponent } from './page-slot.component';

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
@@ -10,9 +10,7 @@ import {
 import {
   CmsService,
   ContentSlotData,
-  JSP_INCLUDE_CMS_COMPONENT_TYPE,
-  ContentSlotComponentData,
-  CMS_FLEX_COMPONENT_TYPE
+  ContentSlotComponentData
 } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
@@ -95,25 +93,5 @@ export class PageSlotComponent implements OnInit {
       'data-smartedit-component-uuid',
       slot.uuid
     );
-  }
-
-  /**
-   * The "JspIncludeComponent" and "CMSFlexComponent" are types of CmsComponent that behave
-   * as a placeholder component (with no specific data provided).
-   *
-   * While it's not very clean solution, we interpret the "uid" of the "JspIncludeComponent" and "flexType" of "CMSFlexComponent"
-   * as a component type and thanks to that we map it onto the implementation of the Angular (or web) component.
-   *
-   * CAUTION: The mapped type should not be used for SmartEdit bindings.
-   */
-  getComponentMappedType(component: ContentSlotComponentData): string {
-    switch (component.typeCode) {
-      case JSP_INCLUDE_CMS_COMPONENT_TYPE:
-        return component.uid;
-      case CMS_FLEX_COMPONENT_TYPE:
-        return component.flexType;
-      default:
-        return component.typeCode;
-    }
   }
 }


### PR DESCRIPTION
The logical type for components is mainly driven by the component `typeCode`, however in case of a `FlexComponent` (or `JspIncludeComponent`), the logical type is dictated by an attribute. The logic to extract the attribute will be populated in an effect, to not bother the UI implementation.

closes #1681 