### PR TITLE
GH-1453: Fix various typos

### DIFF
--- a/docs/architecture/seo.md
+++ b/docs/architecture/seo.md
@@ -22,7 +22,7 @@ To serve stateful URLs for everything, Spartacus allow deep links to address any
 
 ## Configurable URLs
 
-You can configure URLs for content pages by using the `pagelabel` in the CMS (back end). These page labels cannot be localized.
+You can configure URLs for content pages by using the `pageLabel` in the CMS (back end). These page labels cannot be localized.
 
 You can configure URLs for non-content pages in Spartacus. These are mainly related to product and category pages. You can configure attributes, such as the product name, to be part of the URL. For example, the default configuration for a product page is `storefront.com/product/1234`, but you can configure the URL to include product-related data, such as the product or category title.
 

--- a/docs/setupandinstallation.md
+++ b/docs/setupandinstallation.md
@@ -86,7 +86,7 @@ $ yarn add @spartacus/styles
 2. Add the `StorefrontModule` to the import section of the `NgModule` decorator:
 
    ```typescript
-   imports: [BrowserModule, StorefrontModule],
+   imports: [BrowserModule, AppRoutingModule, StorefrontModule],
    ```
 
 Your file should look like this:

--- a/projects/storefrontlib/src/lib/occ/docs/cms-component-implementation.md
+++ b/projects/storefrontlib/src/lib/occ/docs/cms-component-implementation.md
@@ -63,7 +63,7 @@ Web components will not have access to the application DI system, regardless of 
 
 A special effort was made to provide web components with both the component-related data, as well as a generic API to tje core services of Spartacus. The input needed for this is `cxApi`.
 
-## Customing Services
+## Customizing Services
 
 Spartacus CMS components that use (complex) business logic will delegate this to a service. This simplifies extensibility, and is also recommended for the following reasons:
 
@@ -111,8 +111,7 @@ ConfigModule.withConfig({
 });
 ```
 
-
-# Placeholder components
+# Placeholder Components
 
 For Angular (or web-) components that don't need any data from CMS (for example *login*) the CMS component of type `CMSFlexComponent` can be used as a placeholder. This CMS component contains the special attribute `flexType` that will be used in the Spartacus' CMS mapping instead of the original component type.
 


### PR DESCRIPTION
Fixed typos or made minor improvements in the following files:

- `setupandinstall.md'
- `seo.md`
- `cms-component-implementation.md`