### PR TITLE
feat: add checkout guard (GH-1182)

### DIFF
--- a/projects/storefrontlib/src/lib/checkout/guards/checkout.guard.spec.ts
+++ b/projects/storefrontlib/src/lib/checkout/guards/checkout.guard.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  NavigationExtras
+} from '@angular/router';
+
+import { of, Observable } from 'rxjs';
+import {
+  AuthService,
+  RoutingService,
+  TranslateUrlOptions,
+  UserToken
+} from '@spartacus/core';
+import { CheckoutGuard } from './checkout.guard';
+
+const mockUserToken = {
+  access_token: 'Mock Access Token',
+  token_type: 'test',
+  refresh_token: 'test',
+  expires_in: 1,
+  scope: ['test'],
+  userId: 'test'
+} as UserToken;
+
+class AuthServiceStub {
+  getUserToken(): Observable<UserToken> {
+    return of();
+  }
+}
+class ActivatedRouteSnapshotStub {}
+class RouterStateSnapshotStub {}
+class RoutingServiceStub {
+  go(
+    _path: any[] | TranslateUrlOptions,
+    _query?: object,
+    _extras?: NavigationExtras
+  ) {}
+  saveRedirectUrl(_url: string) {}
+}
+
+describe('CheckoutGuard', () => {
+  let checkoutGuard: CheckoutGuard;
+  let service: RoutingService;
+  let authService: AuthService;
+  let activatedRouteSnapshot: ActivatedRouteSnapshot;
+  let routerStateSnapshot: RouterStateSnapshot;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        CheckoutGuard,
+        {
+          provide: RoutingService,
+          useClass: RoutingServiceStub
+        },
+        {
+          provide: ActivatedRouteSnapshot,
+          useClass: ActivatedRouteSnapshotStub
+        },
+        {
+          provide: RouterStateSnapshot,
+          useClass: RouterStateSnapshotStub
+        },
+        {
+          provide: AuthService,
+          useClass: AuthServiceStub
+        }
+      ],
+      imports: [RouterTestingModule]
+    });
+    checkoutGuard = TestBed.get(CheckoutGuard);
+    service = TestBed.get(RoutingService);
+    activatedRouteSnapshot = TestBed.get(ActivatedRouteSnapshot);
+    routerStateSnapshot = TestBed.get(RouterStateSnapshot);
+    authService = TestBed.get(AuthService);
+
+    spyOn(service, 'go').and.stub();
+    spyOn(service, 'saveRedirectUrl').and.stub();
+  });
+
+  it('should return false', () => {
+    spyOn(authService, 'getUserToken').and.returnValue(
+      of({ access_token: undefined } as UserToken)
+    );
+    let result: boolean;
+
+    checkoutGuard
+      .canActivate(activatedRouteSnapshot, routerStateSnapshot)
+      .subscribe(value => (result = value))
+      .unsubscribe();
+    expect(result).toBe(false);
+  });
+
+  it('should return true', () => {
+    spyOn(authService, 'getUserToken').and.returnValue(of(mockUserToken));
+
+    let result: boolean;
+
+    checkoutGuard
+      .canActivate(activatedRouteSnapshot, routerStateSnapshot)
+      .subscribe(value => (result = value))
+      .unsubscribe();
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to login if invalid token', () => {
+    spyOn(authService, 'getUserToken').and.returnValue(
+      of({ access_token: undefined } as UserToken)
+    );
+    routerStateSnapshot.url = '/test';
+
+    checkoutGuard
+      .canActivate(activatedRouteSnapshot, routerStateSnapshot)
+      .subscribe()
+      .unsubscribe();
+
+    expect(service.go).toHaveBeenCalledWith(
+      { route: ['login'] },
+      { forced: true }
+    );
+    expect(service.saveRedirectUrl).toHaveBeenCalledWith('/test');
+  });
+});

--- a/projects/storefrontlib/src/lib/checkout/guards/checkout.guard.ts
+++ b/projects/storefrontlib/src/lib/checkout/guards/checkout.guard.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import {
+  CanActivate,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot
+} from '@angular/router';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { AuthService, RoutingService, UserToken } from '@spartacus/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CheckoutGuard implements CanActivate {
+  static GUARD_NAME = 'CheckoutGuard';
+
+  constructor(
+    private routingService: RoutingService,
+    private authService: AuthService
+  ) {}
+
+  canActivate(
+    _route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean> {
+    return this.authService.getUserToken().pipe(
+      map((token: UserToken) => {
+        if (!token.access_token) {
+          this.routingService.go({ route: ['login'] }, { forced: true });
+          this.routingService.saveRedirectUrl(state.url);
+        }
+        return !!token.access_token;
+      })
+    );
+  }
+}

--- a/projects/storefrontlib/src/lib/checkout/guards/index.ts
+++ b/projects/storefrontlib/src/lib/checkout/guards/index.ts
@@ -1,3 +1,4 @@
 import { OrderConfirmationPageGuard } from './order-confirmation-page.guard';
+import { CheckoutGuard } from './checkout.guard';
 
-export const guards: any[] = [OrderConfirmationPageGuard];
+export const guards: any[] = [CheckoutGuard, OrderConfirmationPageGuard];

--- a/projects/storefrontlib/src/lib/ui/pages/pages.module.ts
+++ b/projects/storefrontlib/src/lib/ui/pages/pages.module.ts
@@ -17,6 +17,7 @@ import { HardcodedCheckoutComponent } from './checkout-page.interceptor';
 import { GuardsModule } from './guards/guards.module';
 import { CartNotEmptyGuard } from './guards/cart-not-empty.guard';
 import { LogoutModule } from '../../../cms-components/index';
+import { CheckoutGuard } from '../../checkout/guards/checkout.guard';
 
 const pageModules = [
   CartPageModule,
@@ -55,7 +56,7 @@ const pageModules = [
       },
       {
         path: null,
-        canActivate: [AuthGuard, CmsPageGuard, CartNotEmptyGuard],
+        canActivate: [CheckoutGuard, CmsPageGuard, CartNotEmptyGuard],
         component: PageLayoutComponent,
         data: { pageLabel: 'multiStepCheckoutSummaryPage', cxPath: 'checkout' }
       },


### PR DESCRIPTION
Added checkout guard with `?forced=true` param passed (with unit tests). As for now additional check for cart/user hasn't been introduced (blocked by #1179, RAY-229). Doing this PR so #1387 can be started.

closes GH-1182