### PR TITLE
fix: Get site config from route on init

### DIFF
--- a/projects/core/src/site-context/services/site-context-routes-handler.spec.ts
+++ b/projects/core/src/site-context/services/site-context-routes-handler.spec.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import createSpy = jasmine.createSpy;
 import { SiteContextUrlSerializer } from './site-context-url-serializer';
 
-describe('SiteContextRoutesHandlerService', () => {
+fdescribe('SiteContextRoutesHandlerService', () => {
   let mockRouterEvents;
   let mockRouter;
   let mockLocation;
@@ -76,6 +76,14 @@ describe('SiteContextRoutesHandlerService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should set context parameter on route init', () => {
+    service.init();
+    expect(mockSiteContextParamsService.setValue).toHaveBeenCalledWith(
+      'language',
+      'test'
+    );
   });
 
   it('should set context parameter on route navigation', () => {

--- a/projects/core/src/site-context/services/site-context-routes-handler.spec.ts
+++ b/projects/core/src/site-context/services/site-context-routes-handler.spec.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import createSpy = jasmine.createSpy;
 import { SiteContextUrlSerializer } from './site-context-url-serializer';
 
-fdescribe('SiteContextRoutesHandlerService', () => {
+describe('SiteContextRoutesHandlerService', () => {
   let mockRouterEvents;
   let mockRouter;
   let mockLocation;

--- a/projects/core/src/site-context/services/site-context-routes-handler.spec.ts
+++ b/projects/core/src/site-context/services/site-context-routes-handler.spec.ts
@@ -78,7 +78,7 @@ describe('SiteContextRoutesHandlerService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should set context parameter on route init', () => {
+  it('should set context parameter from route on init', () => {
     service.init();
     expect(mockSiteContextParamsService.setValue).toHaveBeenCalledWith(
       'language',

--- a/projects/core/src/site-context/services/site-context-routes-handler.ts
+++ b/projects/core/src/site-context/services/site-context-routes-handler.ts
@@ -40,6 +40,7 @@ export class SiteContextRoutesHandler implements OnDestroy {
     const routingParams = this.siteContextParams.getContextParameters('route');
 
     if (routingParams.length) {
+      this.setContextParamsFromRoute(this.router.url);
       this.subscribeChanges(routingParams);
       this.subscribeRouting();
     }
@@ -90,6 +91,7 @@ export class SiteContextRoutesHandler implements OnDestroy {
 
   private setContextParamsFromRoute(url: string) {
     const { params } = this.serializer.urlExtractContextParameters(url);
+    console.log(params);
     Object.keys(params).forEach(param =>
       this.siteContextParams.setValue(param, params[param])
     );

--- a/projects/core/src/site-context/services/site-context-routes-handler.ts
+++ b/projects/core/src/site-context/services/site-context-routes-handler.ts
@@ -91,7 +91,6 @@ export class SiteContextRoutesHandler implements OnDestroy {
 
   private setContextParamsFromRoute(url: string) {
     const { params } = this.serializer.urlExtractContextParameters(url);
-    console.log(params);
     Object.keys(params).forEach(param =>
       this.siteContextParams.setValue(param, params[param])
     );


### PR DESCRIPTION
Makes possible to use site context parameters from URL (like baseSite), before first routing event is dispatched.

Closes GH-1819