### PR TITLE
feat: Component guarding

### DIFF
--- a/projects/core/src/cms/config/cms-config.ts
+++ b/projects/core/src/cms/config/cms-config.ts
@@ -38,6 +38,7 @@ export interface CmsComponentMapping {
   childRoutes?: Routes;
   disableSSR?: boolean;
   i18nNamespaces?: string[];
+  guards?: any[];
 }
 
 export interface CMSComponentConfig

--- a/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.spec.ts
+++ b/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.spec.ts
@@ -13,6 +13,8 @@ import { of } from 'rxjs';
 import { CmsPageGuard } from './cms-page.guard';
 import { CmsRoutesService } from '@spartacus/storefront';
 import { CmsI18nService } from '../services/cms-i18n.service';
+import { CmsGuardsService } from '../services/cms-guards.service';
+import { UrlTree } from '@angular/router';
 
 const mockPageComponentTypes = ['component1', 'component2'];
 class MockCmsService {
@@ -41,6 +43,12 @@ class MockCmsI18nService {
   );
 }
 
+class MockCmsGuardsService {
+  cmsPageCanActivate() {
+    return of(true);
+  }
+}
+
 const mockRouteSnapshot: CmsActivatedRouteSnapshot = { data: {} } as any;
 
 describe('CmsPageGuard', () => {
@@ -53,7 +61,8 @@ describe('CmsPageGuard', () => {
         { provide: RoutingService, useClass: MockRoutingService },
         { provide: CmsService, useClass: MockCmsService },
         { provide: CmsRoutesService, useClass: MockCmsRoutesService },
-        { provide: CmsI18nService, useClass: MockCmsI18nService }
+        { provide: CmsI18nService, useClass: MockCmsI18nService },
+        { provide: CmsGuardsService, useClass: MockCmsGuardsService }
       ],
       imports: [RouterTestingModule]
     });
@@ -69,7 +78,7 @@ describe('CmsPageGuard', () => {
       [CmsService, CmsPageGuard],
       (cmsService: CmsService, cmsPageGuard: CmsPageGuard) => {
         spyOn(cmsService, 'hasPage').and.returnValue(of(true));
-        let result: boolean;
+        let result: boolean | UrlTree;
         cmsPageGuard
           .canActivate(mockRouteSnapshot, undefined)
           .subscribe(value => (result = value))
@@ -84,7 +93,7 @@ describe('CmsPageGuard', () => {
       (cmsService: CmsService, cmsPageGuard: CmsPageGuard) => {
         spyOn(cmsService, 'hasPage').and.returnValue(of(false));
 
-        let result: boolean;
+        let result: boolean | UrlTree;
         cmsPageGuard
           .canActivate(mockRouteSnapshot, undefined)
           .subscribe(value => (result = value))

--- a/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.spec.ts
+++ b/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.spec.ts
@@ -44,9 +44,9 @@ class MockCmsI18nService {
 }
 
 class MockCmsGuardsService {
-  cmsPageCanActivate() {
-    return of(true);
-  }
+  cmsPageCanActivate = jasmine
+    .createSpy('cmsPageCanActivate')
+    .and.returnValue(of(true));
 }
 
 const mockRouteSnapshot: CmsActivatedRouteSnapshot = { data: {} } as any;
@@ -134,6 +134,28 @@ describe('CmsPageGuard', () => {
 
         expect(cmsI18n.loadNamespacesForComponents).toHaveBeenCalledWith(
           mockPageComponentTypes
+        );
+      }
+    ));
+
+    it('should process cms guards', inject(
+      [CmsService, CmsGuardsService, CmsPageGuard],
+      (
+        cmsService: CmsService,
+        cmsGuards: CmsGuardsService,
+        cmsPageGuard: CmsPageGuard
+      ) => {
+        spyOn(cmsService, 'hasPage').and.returnValue(of(true));
+
+        cmsPageGuard
+          .canActivate(mockRouteSnapshot, undefined)
+          .subscribe()
+          .unsubscribe();
+
+        expect(cmsGuards.cmsPageCanActivate).toHaveBeenCalledWith(
+          mockPageComponentTypes,
+          mockRouteSnapshot,
+          undefined
         );
       }
     ));

--- a/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.ts
+++ b/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.ts
@@ -40,7 +40,6 @@ export class CmsPageGuard implements CanActivate {
         if (hasPage) {
           return this.cmsService.getPageComponentTypes(pageContext).pipe(
             switchMap(componentTypes =>
-              // authorization logic
               this.cmsGuards
                 .cmsPageCanActivate(componentTypes, route, state)
                 .pipe(withLatestFrom(of(componentTypes)))

--- a/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.ts
+++ b/projects/storefrontlib/src/lib/cms/guards/cms-page.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, RouterStateSnapshot } from '@angular/router';
+import { CanActivate, RouterStateSnapshot, UrlTree } from '@angular/router';
 
 import {
   RoutingService,
@@ -7,10 +7,11 @@ import {
   CmsActivatedRouteSnapshot
 } from '@spartacus/core';
 
-import { combineLatest, Observable, of } from 'rxjs';
-import { switchMap, tap, map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { switchMap, tap, map, first, withLatestFrom } from 'rxjs/operators';
 import { CmsRoutesService } from '../services/cms-routes.service';
 import { CmsI18nService } from '../services/cms-i18n.service';
+import { CmsGuardsService } from '../services/cms-guards.service';
 
 @Injectable()
 export class CmsPageGuard implements CanActivate {
@@ -20,25 +21,38 @@ export class CmsPageGuard implements CanActivate {
     private routingService: RoutingService,
     private cmsService: CmsService,
     private cmsRoutes: CmsRoutesService,
-    private cmsI18n: CmsI18nService
+    private cmsI18n: CmsI18nService,
+    private cmsGuards: CmsGuardsService
   ) {}
 
   canActivate(
     route: CmsActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ): Observable<boolean> {
+  ): Observable<boolean | UrlTree> {
     return this.routingService.getPageContext().pipe(
       switchMap(pageContext =>
-        combineLatest(this.cmsService.hasPage(pageContext), of(pageContext))
+        this.cmsService.hasPage(pageContext).pipe(
+          first(),
+          withLatestFrom(of(pageContext))
+        )
       ),
       switchMap(([hasPage, pageContext]) => {
         if (hasPage) {
           return this.cmsService.getPageComponentTypes(pageContext).pipe(
-            tap(componentTypes =>
-              this.cmsI18n.loadNamespacesForComponents(componentTypes)
+            switchMap(componentTypes =>
+              // authorization logic
+              this.cmsGuards
+                .cmsPageCanActivate(componentTypes, route, state)
+                .pipe(withLatestFrom(of(componentTypes)))
             ),
-            map(componentTypes => {
+            tap(([canActivate, componentTypes]) => {
+              if (canActivate === true) {
+                this.cmsI18n.loadNamespacesForComponents(componentTypes);
+              }
+            }),
+            map(([canActivate, componentTypes]) => {
               if (
+                canActivate === true &&
                 !route.data.cxCmsRouteContext &&
                 !this.cmsRoutes.cmsRouteExist(pageContext.id)
               ) {
@@ -48,7 +62,7 @@ export class CmsPageGuard implements CanActivate {
                   state.url
                 );
               }
-              return true;
+              return canActivate;
             })
           );
         } else {

--- a/projects/storefrontlib/src/lib/cms/services/cms-guards.service.spec.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-guards.service.spec.ts
@@ -2,21 +2,130 @@ import { TestBed } from '@angular/core/testing';
 
 import { CmsGuardsService } from './cms-guards.service';
 import { CmsMappingService } from '@spartacus/storefront';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  RouterStateSnapshot,
+  UrlTree
+} from '@angular/router';
+import { of } from 'rxjs';
 
 describe('CmsGuardsService', () => {
-  beforeEach(() =>
+  let service: CmsGuardsService;
+  let guards: any[];
+  const mockUrlTree = new UrlTree();
+
+  class MockCmsMappingService {
+    getGuardsForComponents = jasmine
+      .createSpy('getGuardsForComponents')
+      .and.returnValue(guards);
+  }
+
+  class PositiveGuard implements CanActivate {
+    canActivate = jasmine
+      .createSpy('PositiveGuard.canActivate')
+      .and.returnValue(true);
+  }
+
+  class PositiveGuardObservable implements CanActivate {
+    canActivate() {
+      return of(true);
+    }
+  }
+
+  class NegativeGuard implements CanActivate {
+    canActivate() {
+      return false;
+    }
+  }
+
+  class UrlTreeGuard implements CanActivate {
+    canActivate() {
+      return mockUrlTree;
+    }
+  }
+
+  const mockActivatedRouteSnapshot: ActivatedRouteSnapshot = 'ActivatedRouteSnapshot ' as any;
+  const mockRouterStateSnapshot: RouterStateSnapshot = 'RouterStateSnapshot' as any;
+
+  beforeEach(() => {
+    guards = [];
     TestBed.configureTestingModule({
       providers: [
         {
           provide: CmsMappingService,
-          useValue: {}
-        }
+          useClass: MockCmsMappingService
+        },
+        PositiveGuard,
+        PositiveGuardObservable,
+        NegativeGuard,
+        UrlTreeGuard
       ]
-    })
-  );
+    });
+    service = TestBed.get(CmsGuardsService);
+  });
 
   it('should be created', () => {
-    const service: CmsGuardsService = TestBed.get(CmsGuardsService);
     expect(service).toBeTruthy();
+  });
+
+  describe('cmsPageCanActivate', () => {
+    it('should resolve to true if not guards are defined', () => {
+      let result;
+      service
+        .cmsPageCanActivate(
+          [],
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        )
+        .subscribe(res => (result = res));
+      expect(result).toEqual(true);
+    });
+
+    it('should resolve to true if all guards resolve to true', () => {
+      guards.push(PositiveGuard, PositiveGuardObservable);
+
+      let result;
+      service
+        .cmsPageCanActivate(
+          [],
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        )
+        .subscribe(res => (result = res));
+      expect(result).toEqual(true);
+      expect(TestBed.get(PositiveGuard).canActivate).toHaveBeenCalledWith(
+        mockActivatedRouteSnapshot,
+        mockRouterStateSnapshot
+      );
+    });
+
+    it('should resolve to false if any guard resolve to false', () => {
+      guards.push(PositiveGuard, NegativeGuard, PositiveGuardObservable);
+
+      let result;
+      service
+        .cmsPageCanActivate(
+          [],
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        )
+        .subscribe(res => (result = res));
+      expect(result).toEqual(false);
+    });
+
+    it('should resolve to UrlTree if any guard resolve to UrlTree', () => {
+      guards.push(PositiveGuard, UrlTreeGuard);
+
+      let result;
+      service
+        .cmsPageCanActivate(
+          [],
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        )
+        .subscribe(res => (result = res));
+      expect(result).toBe(mockUrlTree);
+    });
   });
 });

--- a/projects/storefrontlib/src/lib/cms/services/cms-guards.service.spec.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-guards.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CmsGuardsService } from './cms-guards.service';
+
+describe('CmsGuardsService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: CmsGuardsService = TestBed.get(CmsGuardsService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/storefrontlib/src/lib/cms/services/cms-guards.service.spec.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-guards.service.spec.ts
@@ -1,9 +1,19 @@
 import { TestBed } from '@angular/core/testing';
 
 import { CmsGuardsService } from './cms-guards.service';
+import { CmsMappingService } from '@spartacus/storefront';
 
 describe('CmsGuardsService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: CmsMappingService,
+          useValue: {}
+        }
+      ]
+    })
+  );
 
   it('should be created', () => {
     const service: CmsGuardsService = TestBed.get(CmsGuardsService);

--- a/projects/storefrontlib/src/lib/cms/services/cms-guards.service.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-guards.service.ts
@@ -44,7 +44,9 @@ export class CmsGuardsService {
   }
 }
 
-export function wrapIntoObservable<T>(value: T | Promise<T> | Observable<T>) {
+function wrapIntoObservable<T>(
+  value: T | Promise<T> | Observable<T>
+): Observable<T> {
   if (isObservable(value)) {
     return value;
   }
@@ -56,14 +58,14 @@ export function wrapIntoObservable<T>(value: T | Promise<T> | Observable<T>) {
   return of(value);
 }
 
-export function isPromise(obj: any): obj is Promise<any> {
+function isPromise(obj: any): obj is Promise<any> {
   return !!obj && typeof obj.then === 'function';
 }
 
-export function isCanActivate(guard: any): guard is CanActivate {
+function isCanActivate(guard: any): guard is CanActivate {
   return guard && isFunction<CanActivate>(guard.canActivate);
 }
 
-export function isFunction<T>(v: any): v is T {
+function isFunction<T>(v: any): v is T {
   return typeof v === 'function';
 }

--- a/projects/storefrontlib/src/lib/cms/services/cms-guards.service.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-guards.service.ts
@@ -34,7 +34,7 @@ export class CmsGuardsService {
       });
 
       return concat(...canActivateObservables).pipe(
-        skipWhile(canActivate => canActivate === true),
+        skipWhile((canActivate: boolean | UrlTree) => canActivate === true),
         endWith(true),
         first()
       );

--- a/projects/storefrontlib/src/lib/cms/services/cms-guards.service.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-guards.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Injector } from '@angular/core';
+import { concat, from, isObservable, Observable, of } from 'rxjs';
+import { CanActivate, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { CmsActivatedRouteSnapshot } from '@spartacus/core';
+import { endWith, first, skipWhile } from 'rxjs/operators';
+import { CmsMappingService } from './cms-mapping.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CmsGuardsService {
+  constructor(
+    private cmsMapping: CmsMappingService,
+    private injector: Injector
+  ) {}
+
+  cmsPageCanActivate(
+    componentTypes: string[],
+    route: CmsActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> {
+    const guards = this.cmsMapping.getGuardsForComponents(componentTypes);
+
+    if (guards.length) {
+      const canActivateObservables = guards.map(guardClass => {
+        const guard = this.injector.get<CanActivate>(guardClass, null);
+        if (isCanActivate(guard)) {
+          return wrapIntoObservable(guard.canActivate(route, state)).pipe(
+            first()
+          );
+        } else {
+          throw new Error('Invalid CanActivate guard in cmsMapping');
+        }
+      });
+
+      return concat(...canActivateObservables).pipe(
+        skipWhile(canActivate => canActivate === true),
+        endWith(true),
+        first()
+      );
+    } else {
+      return of(true);
+    }
+  }
+}
+
+export function wrapIntoObservable<T>(value: T | Promise<T> | Observable<T>) {
+  if (isObservable(value)) {
+    return value;
+  }
+
+  if (isPromise(value)) {
+    return from(Promise.resolve(value));
+  }
+
+  return of(value);
+}
+
+export function isPromise(obj: any): obj is Promise<any> {
+  return !!obj && typeof obj.then === 'function';
+}
+
+export function isCanActivate(guard: any): guard is CanActivate {
+  return guard && isFunction<CanActivate>(guard.canActivate);
+}
+
+export function isFunction<T>(v: any): v is T {
+  return typeof v === 'function';
+}

--- a/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.spec.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.spec.ts
@@ -9,13 +9,15 @@ const mockConfig: CmsConfig = {
   cmsComponents: {
     exampleMapping1: {
       selector: 'selector-1',
-      i18nNamespaces: ['namespace-1']
+      i18nNamespaces: ['namespace-1'],
+      guards: ['guard1', 'guard2']
     },
     exampleMapping2: {
       selector: 'selector-2',
       disableSSR: true,
       childRoutes: [{ path: 'route1' }, { path: 'route2' }],
-      i18nNamespaces: ['namespace-1', 'namespace-2']
+      i18nNamespaces: ['namespace-1', 'namespace-2'],
+      guards: ['guard1']
     }
   }
 };
@@ -53,6 +55,15 @@ describe('CmsMappingService', () => {
       expect(service.getRoutesForComponents(mockComponents)).toEqual([
         { path: 'route1' },
         { path: 'route2' }
+      ]);
+    });
+  });
+
+  describe('getGuardsForComponents', () => {
+    it('should get routes from page data', () => {
+      expect(service.getGuardsForComponents(mockComponents)).toEqual([
+        'guard1',
+        'guard2'
       ]);
     });
   });

--- a/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { CmsConfig } from '@spartacus/core';
-import { Route } from '@angular/router';
+import { CanActivate, Route } from '@angular/router';
 import { isPlatformServer } from '@angular/common';
 
 @Injectable({
@@ -29,6 +29,16 @@ export class CmsMappingService {
     return routes;
   }
 
+  getGuardsForComponents(componentTypes: string[]): any[] {
+    const guards = new Set<CanActivate>();
+    for (const componentType of componentTypes) {
+      this.getGuardsForComponent(componentType).forEach(guard =>
+        guards.add(guard)
+      );
+    }
+    return Array.from(guards);
+  }
+
   getI18nNamespacesForComponents(componentTypes: string[]): string[] {
     const namespaces = new Set<string>();
     for (const componentType of componentTypes) {
@@ -44,6 +54,11 @@ export class CmsMappingService {
   private getRoutesForComponent(componentType: string): Route[] {
     const mappingConfig = this.config.cmsComponents[componentType];
     return (mappingConfig && mappingConfig.childRoutes) || [];
+  }
+
+  private getGuardsForComponent(componentType: string): CanActivate[] {
+    const mappingConfig = this.config.cmsComponents[componentType];
+    return (mappingConfig && mappingConfig.guards) || [];
   }
 
   private getNamespaces18NForComponent(componentType: string): string[] {

--- a/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.ts
@@ -56,7 +56,7 @@ export class CmsMappingService {
     return (mappingConfig && mappingConfig.childRoutes) || [];
   }
 
-  private getGuardsForComponent(componentType: string): CanActivate[] {
+  private getGuardsForComponent(componentType: string): any[] {
     const mappingConfig = this.config.cmsComponents[componentType];
     return (mappingConfig && mappingConfig.guards) || [];
   }

--- a/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.ts
+++ b/projects/storefrontlib/src/lib/cms/services/cms-mapping.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { CmsConfig } from '@spartacus/core';
-import { CanActivate, Route } from '@angular/router';
+import { Route } from '@angular/router';
 import { isPlatformServer } from '@angular/common';
 
 @Injectable({
@@ -30,7 +30,7 @@ export class CmsMappingService {
   }
 
   getGuardsForComponents(componentTypes: string[]): any[] {
-    const guards = new Set<CanActivate>();
+    const guards = new Set<any>();
     for (const componentType of componentTypes) {
       this.getGuardsForComponent(componentType).forEach(guard =>
         guards.add(guard)


### PR DESCRIPTION
Some pages require authentication. Authentication can be page driven, but it's actually based on components used on the pages; components that require authorised users can moved by users from page to page.

For the CMS we've suggested to return a 403, but for non-cms use-cases (and for as long as the cms doesn't provide auth per page), we like to use a setting per component type, that instructs the UI to redirect to the login page in case there's no authenticated user.

The component guard instructions must be evaluated during page load, and in case any guarded component is part of the page, the user must be redirected.

The login page is currently a hard-coded route.

The component guard configuration can be part of the component mapping configuration.

Closes GH-1678