### PR TITLE
fix(storefront): warn when CMS component not added to entry components

### DIFF
--- a/projects/core/src/cms/services/component-mapper.service.ts
+++ b/projects/core/src/cms/services/component-mapper.service.ts
@@ -48,10 +48,8 @@ export class ComponentMapperService {
       if (this.missingComponents.indexOf(typeCode) === -1) {
         this.missingComponents.push(typeCode);
         console.warn(
-          'No component implementation found for the CMS component type',
-          typeCode,
-          '.\n',
-          'Make sure you implement a component and register it in the mapper.'
+          `No component implementation found for the CMS component type '${typeCode}'.\n`,
+          `Make sure you implement a component and register it in the mapper.`
         );
       }
     }
@@ -67,7 +65,16 @@ export class ComponentMapperService {
       this.componentFactoryResolver['_factories'].entries()
     );
 
-    return factoryEntries.find(([, value]: any) => value.selector === alias);
+    const factory = factoryEntries.find(
+      ([, value]: any) => value.selector === alias
+    );
+    if (!factory) {
+      console.warn(
+        `No component factory found for the CMS component type '${typeCode}'.\n`,
+        `Make sure you add a component to the 'entryComponents' of the NgModule.`
+      );
+    }
+    return factory;
   }
 
   getComponentTypeByCode(typeCode: string): Type<any> {

--- a/projects/core/src/cms/services/component-mapper.service.ts
+++ b/projects/core/src/cms/services/component-mapper.service.ts
@@ -71,7 +71,7 @@ export class ComponentMapperService {
     if (!factory) {
       console.warn(
         `No component factory found for the CMS component type '${typeCode}'.\n`,
-        `Make sure you add a component to the 'entryComponents' of the NgModule.`
+        `Make sure you add a component to the 'entryComponents' array in the NgModule.`
       );
     }
     return factory;


### PR DESCRIPTION
Currently we have a warning in the console, when the CMS component doens't have a mapping in the configuration.

But there may be a case when the mapping is provided, but the developer forgot to add the component reference into `entryComponent` array. Then the component doesn't show up and there is no hint what went wrong.

fixes GH-1897