### PR TITLE
feat(core): add category name to page title resolver

### DIFF
--- a/projects/core/src/product/services/product-page-meta.resolver.spec.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.spec.ts
@@ -1,16 +1,15 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { PageType } from '../../occ/occ-models/occ.models';
+import { inject, TestBed } from '@angular/core/testing';
 import { Observable, of } from 'rxjs';
 import {
-  Page,
-  PageMetaResolver,
   CmsService,
-  PageMetaService,
+  Page,
   PageMeta,
+  PageMetaResolver,
+  PageMetaService,
 } from '../../cms';
-import { ProductService } from '../facade';
+import { PageType } from '../../occ/occ-models/occ.models';
 import { RoutingService } from '../../routing';
+import { ProductService } from '../facade';
 import { ProductPageMetaResolver } from './product-page-meta.resolver';
 
 const mockProductPage: Page = {
@@ -46,6 +45,7 @@ class MockProductService {
       categories: [
         {
           code: '123',
+          name: 'one two three',
         },
       ],
       images: {
@@ -110,7 +110,7 @@ describe('ProductPageMetaResolver', () => {
       })
       .unsubscribe();
 
-    expect(result.title).toEqual('Product title | 123 | Canon');
+    expect(result.title).toEqual('Product title | one two three | Canon');
   });
 
   it('should resolve product description', () => {

--- a/projects/core/src/product/services/product-page-meta.resolver.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.ts
@@ -1,17 +1,17 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map, filter, switchMap } from 'rxjs/operators';
-import { RoutingService } from '../../routing/facade/routing.service';
-import { ProductService } from '../facade/product.service';
-import { PageType, Product } from '../../occ/occ-models/occ.models';
-import { PageMetaResolver } from '../../cms/page/page-meta.resolver';
+import { filter, map, switchMap } from 'rxjs/operators';
 import { PageMeta } from '../../cms/model/page.model';
+import { PageMetaResolver } from '../../cms/page/page-meta.resolver';
 import {
-  PageTitleResolver,
   PageDescriptionResolver,
   PageHeadingResolver,
   PageImageResolver,
+  PageTitleResolver,
 } from '../../cms/page/page.resolvers';
+import { PageType, Product } from '../../occ/occ-models/occ.models';
+import { RoutingService } from '../../routing/facade/routing.service';
+import { ProductService } from '../facade/product.service';
 
 @Injectable({
   providedIn: 'root',
@@ -78,8 +78,12 @@ export class ProductPageMetaResolver extends PageMetaResolver
   }
 
   private resolveFirstCategory(product: Product): string {
-    return product.categories && product.categories.length > 0
-      ? ` | ${product.categories[0].code}`
+    let firstCategory;
+    if (product.categories && product.categories.length > 0) {
+      firstCategory = product.categories[0];
+    }
+    return firstCategory
+      ? ` | ${firstCategory.name || firstCategory.code}`
       : '';
   }
 


### PR DESCRIPTION
To improve SEO (especially the title on the SERP), the category name is resolved as part of the page title. The format looks like: **Product name | category name | manufacturer**

A specific page title can be added by providing a custom `ProductPageMetaResolver`.

closes #2003 