### PR TITLE
refactor(core) : change interfaces of page meta resolvers to observable

### DIFF
--- a/projects/core/src/checkout/services/checkout-page-meta.resolver.ts
+++ b/projects/core/src/checkout/services/checkout-page-meta.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of, combineLatest } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { RoutingService } from '../../routing/facade/routing.service';
 import { PageType } from '../../occ/occ-models/occ.models';
 import { CartService } from '../../cart/facade/cart.service';
@@ -28,20 +28,18 @@ export class CheckoutPageMetaResolver extends PageMetaResolver
 
   resolve(): Observable<PageMeta> {
     return this.cartService.getActive().pipe(
-      map(cart => {
-        return {
-          title: this.resolveTitle(cart),
-          robots: this.resolveRobots(),
-        };
-      })
+      switchMap(cart =>
+        combineLatest([this.resolveTitle(cart), this.resolveRobots()])
+      ),
+      map(([title, robots]) => ({ title, robots }))
     );
   }
 
-  resolveTitle(cart: UICart) {
-    return `Checkout ${cart.totalItems} items`;
+  resolveTitle(cart: UICart): Observable<string> {
+    return of(`Checkout ${cart.totalItems} items`);
   }
 
-  resolveRobots(): PageRobotsMeta[] {
-    return [PageRobotsMeta.NOFOLLOW, PageRobotsMeta.NOINDEX];
+  resolveRobots(): Observable<PageRobotsMeta[]> {
+    return of([PageRobotsMeta.NOFOLLOW, PageRobotsMeta.NOINDEX]);
   }
 }

--- a/projects/core/src/cms/page/content-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/content-page-meta.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { map, filter, switchMap } from 'rxjs/operators';
 import { PageType } from '../../occ/occ-models/occ.models';
 import { CmsService } from '../facade/cms.service';
 import { PageMetaResolver } from './page-meta.resolver';
@@ -20,15 +20,12 @@ export class ContentPageMetaResolver extends PageMetaResolver
   resolve(): Observable<PageMeta> {
     return this.cms.getCurrentPage().pipe(
       filter(Boolean),
-      map(page => {
-        return {
-          title: this.resolveTitle(page),
-        };
-      })
+      switchMap(page => this.resolveTitle(page)),
+      map((title): PageMeta => ({ title }))
     );
   }
 
-  resolveTitle(page: Page) {
-    return page.title;
+  resolveTitle(page: Page): Observable<string> {
+    return of(page.title);
   }
 }

--- a/projects/core/src/cms/page/page.resolvers.ts
+++ b/projects/core/src/cms/page/page.resolvers.ts
@@ -1,8 +1,11 @@
+import { Observable } from 'rxjs';
+import { PageRobotsMeta } from '../model/page.model';
+
 /**
  * Resolves the page heading which is used in the UI.
  */
 export interface PageHeadingResolver {
-  resolveHeading(...args);
+  resolveHeading(...args): Observable<string>;
 }
 
 /**
@@ -11,7 +14,7 @@ export interface PageHeadingResolver {
  * page heading in the UI.
  */
 export interface PageTitleResolver {
-  resolveTitle(...args);
+  resolveTitle(...args): Observable<string>;
 }
 
 /**
@@ -19,7 +22,7 @@ export interface PageTitleResolver {
  * in the Search Engine Result Page (SERP).
  */
 export interface PageDescriptionResolver {
-  resolveDescription(...args);
+  resolveDescription(...args): Observable<string>;
 }
 
 /**
@@ -27,7 +30,7 @@ export interface PageDescriptionResolver {
  * for social sharing (using `og:image` metatag)
  */
 export interface PageImageResolver {
-  resolveImage(...args): string;
+  resolveImage(...args): Observable<string>;
 }
 
 /**
@@ -37,5 +40,5 @@ export interface PageImageResolver {
  *
  */
 export interface PageRobotsResolver {
-  resolveRobots(...args);
+  resolveRobots(...args): Observable<PageRobotsMeta[]>;
 }

--- a/projects/core/src/product/services/category-page-meta.resolver.ts
+++ b/projects/core/src/product/services/category-page-meta.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { filter, map, switchMap } from 'rxjs/operators';
 import { RoutingService } from '../../routing/facade/routing.service';
 import { CmsService } from '../../cms/facade/cms.service';
 import { Page, PageMeta } from '../../cms/model/page.model';

--- a/projects/core/src/product/services/category-page-meta.resolver.ts
+++ b/projects/core/src/product/services/category-page-meta.resolver.ts
@@ -43,13 +43,11 @@ export class CategoryPageMetaResolver extends PageMetaResolver
             title: page.title || page.name,
           });
         }
-      }),
-      tap(console.log) //spike
+      })
     );
   }
 
   resolveTitle(data: UIProductSearchPage): Observable<string> {
-    console.log(data);
     return of(
       `${data.pagination.totalResults} results for ${
         data.breadcrumbs[0].facetValueName

--- a/projects/core/src/product/services/category-page-meta.resolver.ts
+++ b/projects/core/src/product/services/category-page-meta.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { RoutingService } from '../../routing/facade/routing.service';
 import { CmsService } from '../../cms/facade/cms.service';
 import { Page, PageMeta } from '../../cms/model/page.model';
@@ -33,12 +33,9 @@ export class CategoryPageMetaResolver extends PageMetaResolver
         // are rendered or if this is an ordinary content page
         if (this.hasProductListComponent(page)) {
           return this.productSearchService.getSearchResults().pipe(
-            map(data => {
-              if (data.breadcrumbs && data.breadcrumbs.length > 0) {
-                return {
-                  title: this.resolveTitle(data),
-                };
-              }
+            filter(data => data.breadcrumbs && data.breadcrumbs.length > 0),
+            switchMap(data => {
+              return this.resolveTitle(data).pipe(map(title => ({ title })));
             })
           );
         } else {
@@ -46,14 +43,18 @@ export class CategoryPageMetaResolver extends PageMetaResolver
             title: page.title || page.name,
           });
         }
-      })
+      }),
+      tap(console.log) //spike
     );
   }
 
-  resolveTitle(data: UIProductSearchPage) {
-    return `${data.pagination.totalResults} results for ${
-      data.breadcrumbs[0].facetValueName
-    }`;
+  resolveTitle(data: UIProductSearchPage): Observable<string> {
+    console.log(data);
+    return of(
+      `${data.pagination.totalResults} results for ${
+        data.breadcrumbs[0].facetValueName
+      }`
+    );
   }
 
   protected hasProductListComponent(page: Page): boolean {

--- a/projects/core/src/product/services/product-page-meta.resolver.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.ts
@@ -32,15 +32,11 @@ export class ProductPageMetaResolver extends PageMetaResolver
   }
 
   resolve(): Observable<PageMeta> {
-    const product$: Observable<
-      UIProduct
-    > = this.routingService.getRouterState().pipe(
+    return this.routingService.getRouterState().pipe(
       map(state => state.state.params['productCode']),
       filter(Boolean),
-      switchMap(code => this.productService.get(code))
-    );
-
-    return product$.pipe(
+      switchMap(code => this.productService.get(code)),
+      filter(Boolean),
       switchMap((p: UIProduct) =>
         combineLatest([
           this.resolveHeading(p),

--- a/projects/core/src/product/services/product-page-meta.resolver.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.ts
@@ -45,16 +45,12 @@ export class ProductPageMetaResolver extends PageMetaResolver
               this.resolveImage(p),
             ])
           ),
-          map(([heading, title, description, image]) => {
-            console.log([heading, title, description, image]);
-            debugger;
-            return {
-              heading,
-              title,
-              description,
-              image,
-            };
-          })
+          map(([heading, title, description, image]) => ({
+            heading,
+            title,
+            description,
+            image,
+          }))
         )
       )
     );

--- a/projects/core/src/product/services/search-page-meta.resolver.ts
+++ b/projects/core/src/product/services/search-page-meta.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable, combineLatest } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { Observable, combineLatest, of } from 'rxjs';
+import { map, filter, switchMap } from 'rxjs/operators';
 import { RoutingService } from '../../routing/facade/routing.service';
 import { PageType } from '../../occ/occ-models/occ.models';
 import { ProductSearchService } from '../facade/product-search.service';
@@ -32,15 +32,12 @@ export class SearchPageMetaResolver extends PageMetaResolver
         filter(Boolean)
       )
     ).pipe(
-      map(([t, q]: [number, string]) => {
-        return {
-          title: this.resolveTitle(t, q),
-        };
-      })
+      switchMap(([t, q]: [number, string]) => this.resolveTitle(t, q)),
+      map(title => ({ title }))
     );
   }
 
-  resolveTitle(total: number, part: string) {
-    return `${total} results for "${part}"`;
+  resolveTitle(total: number, part: string): Observable<string> {
+    return of(`${total} results for "${part}"`);
   }
 }


### PR DESCRIPTION
The interfaces for extension points of `PageMetaResolver`s now have `Observable<string>` signature. This allows for async translations of i.e. page title.

fixes GH-2168