### PR TITLE
fix: typo in update profile

### DIFF
--- a/projects/storefrontlib/src/cms-components/myaccount/update-profile/components/update-profile-form.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/update-profile/components/update-profile-form.component.html
@@ -42,7 +42,7 @@
     <div class="col-md-12">
       <label>
         <span class="label-content">{{
-          'updateProfileForm.LastName.label' | cxTranslate
+          'updateProfileForm.lastName.label' | cxTranslate
         }}</span>
         <input
           type="text"


### PR DESCRIPTION
Fix a typo which causes not translated label at profile update view.