### PR TITLE
refactor: rename type DatePipe to CxDatePipe

### DIFF
--- a/projects/core/src/i18n/date.pipe.spec.ts
+++ b/projects/core/src/i18n/date.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { DatePipe } from './date.pipe';
+import { CxDatePipe } from './date.pipe';
 import { LanguageService } from '../site-context';
 import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de';
@@ -10,7 +10,7 @@ const mockDate = '2017-01-11T10:14:39+0000';
 const mockDateFormat = 'longDate';
 
 describe('DatePipe', () => {
-  let pipe: DatePipe;
+  let pipe: CxDatePipe;
   let languageService: LanguageService;
 
   beforeEach(() => {
@@ -20,13 +20,13 @@ describe('DatePipe', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        DatePipe,
+        CxDatePipe,
         { provide: LanguageService, useValue: mockLanguageService },
         { provide: I18nConfig, useValue: { production: false } },
       ],
     });
 
-    pipe = TestBed.get(DatePipe);
+    pipe = TestBed.get(CxDatePipe);
     languageService = TestBed.get(LanguageService);
   });
 

--- a/projects/core/src/i18n/date.pipe.ts
+++ b/projects/core/src/i18n/date.pipe.ts
@@ -1,11 +1,12 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { DatePipe as NativeDatePipe } from '@angular/common';
+import { DatePipe } from '@angular/common';
 import { getLocaleId } from '@angular/common';
 import { LanguageService } from '../site-context/facade/language.service';
 import { I18nConfig } from './config/i18n-config';
 
+// type CxDatePipe, not DatePipe, due to conflict with Angular's DatePipe - problem occurs for the backward compatibility compiler of Ivy
 @Pipe({ name: 'cxDate' })
-export class DatePipe extends NativeDatePipe implements PipeTransform {
+export class CxDatePipe extends DatePipe implements PipeTransform {
   constructor(private language: LanguageService, private config: I18nConfig) {
     super(null);
   }

--- a/projects/core/src/i18n/i18n.module.ts
+++ b/projects/core/src/i18n/i18n.module.ts
@@ -6,12 +6,12 @@ import { I18nConfig } from './config/i18n-config';
 import { TranslationService } from './translation.service';
 import { provideConfig, Config } from '../config/config.module';
 import { I18nextTranslationService } from './i18next/i18next-translation.service';
-import { DatePipe } from './date.pipe';
+import { CxDatePipe } from './date.pipe';
 import { TranslationChunkService } from './translation-chunk.service';
 
 @NgModule({
-  declarations: [TranslatePipe, DatePipe],
-  exports: [TranslatePipe, DatePipe],
+  declarations: [TranslatePipe, CxDatePipe],
+  exports: [TranslatePipe, CxDatePipe],
 })
 export class I18nModule {
   static forRoot(): ModuleWithProviders {

--- a/projects/core/src/i18n/testing/mock-date.pipe.ts
+++ b/projects/core/src/i18n/testing/mock-date.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { DatePipe as NativeDatePipe } from '@angular/common';
+import { DatePipe } from '@angular/common';
 
 @Pipe({ name: 'cxDate' })
-export class MockDatePipe extends NativeDatePipe implements PipeTransform {
+export class MockDatePipe extends DatePipe implements PipeTransform {
   transform(value: any, format?: string, timezone?: string): string {
     return super.transform(value, format, timezone, 'en');
   }


### PR DESCRIPTION
The backward compatibility compiler of Angular Ivy had problem with our `DatePipe` type, probably due to the conflict with Angular's native `DatePipe`. So as a workaround, we rename the type to `CxDatePipe`.

close GH-2344