### PR TITLE
Reuse existing type UserSignUp

### DIFF
--- a/projects/core/src/model/misc.model.ts
+++ b/projects/core/src/model/misc.model.ts
@@ -66,3 +66,11 @@ export interface ErrorModel {
   subjectType?: string;
   type?: string;
 }
+
+export interface UserSignUp {
+  firstName?: string;
+  lastName?: string;
+  password?: string;
+  titleCode?: string;
+  uid?: string;
+}

--- a/projects/core/src/model/unused.model.ts
+++ b/projects/core/src/model/unused.model.ts
@@ -1,13 +1,9 @@
 import { Address } from './address.model';
 import { Image } from './image.model';
 import { Product, Stock } from './product.model';
-import {
-  GeoPoint,
-  OpeningSchedule,
-  PaginationModel,
-  SortModel,
-} from './misc.model';
+import { GeoPoint, PaginationModel, SortModel } from './misc.model';
 import { Cart, Principal } from './cart.model';
+import { OpeningSchedule } from './point-of-service.model';
 
 export interface CategoryHierarchy {
   id?: string;
@@ -120,12 +116,4 @@ export interface UserGroupList {
   pageSize?: number;
   totalNumber?: number;
   userGroups?: UserGroup[];
-}
-
-export interface UserSignUp {
-  firstName?: string;
-  lastName?: string;
-  password?: string;
-  titleCode?: string;
-  uid?: string;
 }

--- a/projects/core/src/occ/adapters/user/occ-user-account.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-account.adapter.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { Title, User } from '../../../model/misc.model';
+import { Title, User, UserSignUp } from '../../../model/misc.model';
 import {
   ConsentTemplate,
   ConsentTemplateList,
@@ -19,7 +19,6 @@ import {
 } from '../../../user/connectors/account/converters';
 import { UserAccountAdapter } from '../../../user/connectors/account/user-account.adapter';
 import { USER_NORMALIZER } from '../../../user/connectors/details/converters';
-import { UserRegisterFormData } from '../../../user/model/user.model';
 import { Occ } from '../../occ-models';
 
 const USER_ENDPOINT = 'users/';
@@ -43,7 +42,7 @@ export class OccUserAccountAdapter implements UserAccountAdapter {
     const endpoint = userId ? `${USER_ENDPOINT}${userId}` : USER_ENDPOINT;
     return this.occEndpoints.getEndpoint(endpoint);
   }
-  register(user: UserRegisterFormData): Observable<User> {
+  register(user: UserSignUp): Observable<User> {
     const url: string = this.getUserEndpoint();
     let headers = new HttpHeaders({
       'Content-Type': 'application/json',

--- a/projects/core/src/occ/adapters/user/occ-user-account.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-account.adapter.ts
@@ -15,7 +15,7 @@ import {
 import { ConverterService } from '../../../util/converter.service';
 import {
   TITLE_NORMALIZER,
-  USER_REGISTER_FORM_SERIALIZER,
+  USER_SIGN_UP_SERIALIZER,
 } from '../../../user/connectors/account/converters';
 import { UserAccountAdapter } from '../../../user/connectors/account/user-account.adapter';
 import { USER_NORMALIZER } from '../../../user/connectors/details/converters';
@@ -48,7 +48,7 @@ export class OccUserAccountAdapter implements UserAccountAdapter {
       'Content-Type': 'application/json',
     });
     headers = InterceptorUtil.createHeader(USE_CLIENT_TOKEN, true, headers);
-    user = this.converter.convert(user, USER_REGISTER_FORM_SERIALIZER);
+    user = this.converter.convert(user, USER_SIGN_UP_SERIALIZER);
 
     return this.http.post<User>(url, user, { headers }).pipe(
       catchError((error: any) => throwError(error)),

--- a/projects/core/src/user/connectors/account/converters.ts
+++ b/projects/core/src/user/connectors/account/converters.ts
@@ -2,9 +2,9 @@ import { InjectionToken } from '@angular/core';
 import { Converter } from '../../../util/converter.service';
 import { Title, UserSignUp } from '../../../model/misc.model';
 
-export const USER_REGISTER_FORM_SERIALIZER = new InjectionToken<
+export const USER_SIGN_UP_SERIALIZER = new InjectionToken<
   Converter<UserSignUp, any>
->('UserRegisterFormSerializer');
+>('UserSignUpSerializer');
 
 export const TITLE_NORMALIZER = new InjectionToken<Converter<any, Title>>(
   'TitleNormalizer'

--- a/projects/core/src/user/connectors/account/converters.ts
+++ b/projects/core/src/user/connectors/account/converters.ts
@@ -1,10 +1,9 @@
 import { InjectionToken } from '@angular/core';
 import { Converter } from '../../../util/converter.service';
-import { UserRegisterFormData } from '../../model/user.model';
-import { Title } from '../../../model/misc.model';
+import { Title, UserSignUp } from '../../../model/misc.model';
 
 export const USER_REGISTER_FORM_SERIALIZER = new InjectionToken<
-  Converter<UserRegisterFormData, any>
+  Converter<UserSignUp, any>
 >('UserRegisterFormSerializer');
 
 export const TITLE_NORMALIZER = new InjectionToken<Converter<any, Title>>(

--- a/projects/core/src/user/connectors/account/user-account.adapter.ts
+++ b/projects/core/src/user/connectors/account/user-account.adapter.ts
@@ -1,13 +1,12 @@
 import { Observable } from 'rxjs';
-import { Title, User } from '../../../model/misc.model';
+import { Title, User, UserSignUp } from '../../../model/misc.model';
 import {
   ConsentTemplate,
   ConsentTemplateList,
 } from '../../../occ/occ-models/additional-occ.models';
-import { UserRegisterFormData } from '../../../user/model/user.model';
 
 export abstract class UserAccountAdapter {
-  abstract register(user: UserRegisterFormData): Observable<User>;
+  abstract register(user: UserSignUp): Observable<User>;
 
   abstract requestForgotPasswordEmail(userEmailAddress: string): Observable<{}>;
 

--- a/projects/core/src/user/connectors/account/user-account.connector.spec.ts
+++ b/projects/core/src/user/connectors/account/user-account.connector.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { UserRegisterFormData } from '@spartacus/core';
+import { UserSignUp } from '@spartacus/core';
 import { of } from 'rxjs/internal/observable/of';
 import { UserAccountAdapter } from './user-account.adapter';
 import { UserAccountConnector } from './user-account.connector';
@@ -42,7 +42,7 @@ describe('UserAccountConnector', () => {
   it('register should call adapter', () => {
     let result;
 
-    const registerData: UserRegisterFormData = {
+    const registerData: UserSignUp = {
       firstName: 'name',
       lastName: 'name',
       password: 'pass',

--- a/projects/core/src/user/connectors/account/user-account.connector.ts
+++ b/projects/core/src/user/connectors/account/user-account.connector.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { Title, User } from '../../../model/misc.model';
+import { Title, User, UserSignUp } from '../../../model/misc.model';
 import {
   ConsentTemplate,
   ConsentTemplateList,
 } from '../../../occ/occ-models/additional-occ.models';
-import { UserRegisterFormData } from '../../../user/model/user.model';
 import { UserAccountAdapter } from './user-account.adapter';
 
 @Injectable({
@@ -14,7 +13,7 @@ import { UserAccountAdapter } from './user-account.adapter';
 export class UserAccountConnector {
   constructor(protected adapter: UserAccountAdapter) {}
 
-  register(user: UserRegisterFormData): Observable<User> {
+  register(user: UserSignUp): Observable<User> {
     return this.adapter.register(user);
   }
 

--- a/projects/core/src/user/facade/user.service.spec.ts
+++ b/projects/core/src/user/facade/user.service.spec.ts
@@ -2,13 +2,12 @@ import { inject, TestBed } from '@angular/core/testing';
 import { Store, StoreModule } from '@ngrx/store';
 import { Address, Country, Region } from '../../model/address.model';
 import { PaymentDetails } from '../../model/cart.model';
-import { Title, User } from '../../model/misc.model';
+import { Title, User, UserSignUp } from '../../model/misc.model';
 import { Order, OrderHistoryList } from '../../model/order.model';
 import { ConsentTemplateList } from '../../occ/occ-models/additional-occ.models';
 import { Occ } from '../../occ/occ-models/occ.models';
 import { PROCESS_FEATURE } from '../../process/store/process-state';
 import * as fromProcessReducers from '../../process/store/reducers';
-import { UserRegisterFormData } from '../model/user.model';
 import * as fromStore from '../store/index';
 import { USER_FEATURE } from '../store/user-state';
 import { UserService } from './user.service';
@@ -65,7 +64,7 @@ describe('UserService', () => {
   });
 
   it('should be able to register user', () => {
-    const userRegisterFormData: UserRegisterFormData = {
+    const userRegisterFormData: UserSignUp = {
       titleCode: 'Mr.',
       firstName: 'firstName',
       lastName: 'lastName',

--- a/projects/core/src/user/facade/user.service.ts
+++ b/projects/core/src/user/facade/user.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { Address, Country, Region } from '../../model/address.model';
 import { PaymentDetails } from '../../model/cart.model';
-import { Title, User } from '../../model/misc.model';
+import { Title, User, UserSignUp } from '../../model/misc.model';
 import { Order, OrderHistoryList } from '../../model/order.model';
 import { ConsentTemplateList } from '../../occ/occ-models/additional-occ.models';
 import * as fromProcessStore from '../../process/store/process-state';
@@ -13,7 +13,6 @@ import {
   getProcessLoadingFactory,
   getProcessSuccessFactory,
 } from '../../process/store/selectors/process.selectors';
-import { UserRegisterFormData } from '../model/user.model';
 import * as fromStore from '../store/index';
 import {
   GIVE_CONSENT_PROCESS_ID,
@@ -49,7 +48,7 @@ export class UserService {
    *
    * @param submitFormData as UserRegisterFormData
    */
-  register(userRegisterFormData: UserRegisterFormData): void {
+  register(userRegisterFormData: UserSignUp): void {
     this.store.dispatch(new fromStore.RegisterUser(userRegisterFormData));
   }
 

--- a/projects/core/src/user/index.ts
+++ b/projects/core/src/user/index.ts
@@ -2,7 +2,6 @@ export * from './store/actions/index';
 export * from './store/selectors/index';
 export * from './store/user-state';
 
-export * from './model/user.model';
 export * from './facade/index';
 export * from './user.module';
 export * from './connectors/index';

--- a/projects/core/src/user/model/user.model.ts
+++ b/projects/core/src/user/model/user.model.ts
@@ -1,7 +1,0 @@
-export interface UserRegisterFormData {
-  lastName: string;
-  firstName: string;
-  uid: string;
-  password: string;
-  titleCode: string;
-}

--- a/projects/core/src/user/store/actions/user-register.action.spec.ts
+++ b/projects/core/src/user/store/actions/user-register.action.spec.ts
@@ -7,12 +7,12 @@ import {
 } from '../../../state';
 import { REMOVE_USER_PROCESS_ID } from '../user-state';
 import * as fromUserRegister from './user-register.action';
-import { UserRegisterFormData } from '../../model/user.model';
+import { UserSignUp } from '@spartacus/core';
 
 describe('User Register Actions', () => {
   describe('RegisterUser Action', () => {
     it('should create the action', () => {
-      const user: UserRegisterFormData = {
+      const user: UserSignUp = {
         titleCode: '',
         firstName: '',
         lastName: '',

--- a/projects/core/src/user/store/actions/user-register.action.ts
+++ b/projects/core/src/user/store/actions/user-register.action.ts
@@ -1,6 +1,5 @@
 import { Action } from '@ngrx/store';
 
-import { UserRegisterFormData } from '../../model/user.model';
 import { PROCESS_FEATURE } from '../../../process/store/process-state';
 import {
   EntityFailAction,
@@ -9,6 +8,7 @@ import {
   EntitySuccessAction,
 } from '../../../state';
 import { REMOVE_USER_PROCESS_ID } from '../user-state';
+import { UserSignUp } from '../../../model/misc.model';
 
 export const REGISTER_USER = '[User] Register User';
 export const REGISTER_USER_FAIL = '[User] Register User Fail';
@@ -21,7 +21,7 @@ export const REMOVE_USER_RESET = '[User] Reset Remove User Process State';
 
 export class RegisterUser implements Action {
   readonly type = REGISTER_USER;
-  constructor(public payload: UserRegisterFormData) {}
+  constructor(public payload: UserSignUp) {}
 }
 
 export class RegisterUserFail implements Action {

--- a/projects/core/src/user/store/effects/user-register.effect.spec.ts
+++ b/projects/core/src/user/store/effects/user-register.effect.spec.ts
@@ -6,12 +6,12 @@ import { cold, hot } from 'jasmine-marbles';
 
 import * as fromStore from '../index';
 import { UserRegisterEffects } from './user-register.effect';
-import { UserRegisterFormData } from '../../../user/index';
+import { UserSignUp } from '../../../model/misc.model';
 import { LoadUserToken, Logout } from '../../../auth/index';
 import { UserAccountConnector } from '../../connectors/account/user-account.connector';
 import { UserAccountAdapter } from '../../connectors/account/user-account.adapter';
 
-const user: UserRegisterFormData = {
+const user: UserSignUp = {
   firstName: '',
   lastName: '',
   password: '',

--- a/projects/core/src/user/store/effects/user-register.effect.ts
+++ b/projects/core/src/user/store/effects/user-register.effect.ts
@@ -7,8 +7,8 @@ import { catchError, map, mergeMap, switchMap } from 'rxjs/operators';
 
 import * as fromActions from '../actions/user-register.action';
 import { LoadUserToken, Logout } from '../../../auth/index';
-import { UserRegisterFormData } from '../../../user/model/user.model';
 import { UserAccountConnector } from '../../connectors/account/user-account.connector';
+import { UserSignUp } from '../../../model/misc.model';
 
 @Injectable()
 export class UserRegisterEffects {
@@ -18,7 +18,7 @@ export class UserRegisterEffects {
   > = this.actions$.pipe(
     ofType(fromActions.REGISTER_USER),
     map((action: fromActions.RegisterUser) => action.payload),
-    mergeMap((user: UserRegisterFormData) => {
+    mergeMap((user: UserSignUp) => {
       return this.userAccountConnector.register(user).pipe(
         switchMap(_result => [
           new LoadUserToken({

--- a/projects/storefrontapp-e2e-cypress/cypress.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.json
@@ -6,6 +6,6 @@
   "env": {
     "CLIENT_ID": "mobile_android",
     "CLIENT_SECRET": "secret",
-    "API_URL": "https://dev-com-17.accdemo.b2c.ydev.hybris.com:9002"
+    "API_URL": "https://dev-com-19.accdemo.b2c.ydev.hybris.com:9002"
   }
 }

--- a/projects/storefrontapp/src/environments/environment.ci.ts
+++ b/projects/storefrontapp/src/environments/environment.ci.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  occBaseUrl: 'https://dev-com-17.accdemo.b2c.ydev.hybris.com:9002',
+  occBaseUrl: 'https://dev-com-19.accdemo.b2c.ydev.hybris.com:9002',
 };

--- a/projects/storefrontlib/src/cms-components/user/register/register.component.ts
+++ b/projects/storefrontlib/src/cms-components/user/register/register.component.ts
@@ -12,7 +12,7 @@ import {
   GlobalMessageType,
   RoutingService,
   Title,
-  UserRegisterFormData,
+  UserSignUp,
   UserService,
 } from '@spartacus/core';
 import { Observable, of, Subscription } from 'rxjs';
@@ -90,7 +90,7 @@ export class RegisterComponent implements OnInit, OnDestroy {
       password,
       titleCode,
     } = this.userRegistrationForm.value;
-    const userRegisterFormData: UserRegisterFormData = {
+    const userRegisterFormData: UserSignUp = {
       firstName,
       lastName,
       uid: email,


### PR DESCRIPTION
n the register user form we use our custom interface UserRegisterFormData, but we have a standard interface UserSignUp with the same fields already in place (currently in file unused.model.ts). We should remove custom model and reuse the standard one (which can be moved to user.model.ts.