### PR TITLE
fix: Selected filters on search result page reset after selecting a page form the pagination

### DIFF
--- a/projects/storefrontlib/src/cms-components/product/product-list/container/product-list.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-list/container/product-list.component.ts
@@ -116,7 +116,8 @@ export class ProductListComponent implements OnInit {
   }
 
   viewPage(pageNumber: number): void {
-    this.search(this.query, { currentPage: pageNumber });
+    const { queryParams } = this.activatedRoute.snapshot;
+    this.search(queryParams.query, { currentPage: pageNumber });
   }
 
   sortList(sortCode: string): void {


### PR DESCRIPTION
Closes: #2857 