### PR TITLE
fix(storefront): fix null pointer when a media container does not have a URL property

### DIFF
--- a/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
@@ -22,6 +22,7 @@ const mockMediaContainer = {
     url: 'desktopUrl',
     altText: 'alt text',
   },
+  wide: {},
 };
 
 const mockMedia = {
@@ -73,6 +74,10 @@ describe('MediaService', () => {
     expect(mediaService.getMedia(mockMediaContainer, 'desktop').alt).toBe(
       'alt text'
     );
+  });
+
+  it('should return null if the media container has no url', () => {
+    expect(mediaService.getMedia(mockMediaContainer, 'wide').src).toBeFalsy();
   });
 
   it('should not return alt text from media object when alt ', () => {

--- a/projects/storefrontlib/src/shared/components/media/media.service.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.ts
@@ -87,9 +87,12 @@ export class MediaService {
     return srcset === '' ? undefined : srcset;
   }
 
-  private getImageUrl = (url: string) => {
+  private getImageUrl(url: string): string {
+    if (!url) {
+      return null;
+    }
     return url.startsWith('http') ? url : this.getBaseUrl() + url;
-  };
+  }
 
   private getBaseUrl(): string {
     return (


### PR DESCRIPTION
fixes #3034 