### PR TITLE
GH-3046: Update links to point to GH Pages site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ A contribution will be considered for inclusion in Spartacus if it meets the fol
 * The contribution truly improves the storefront
 * The contribution follows the applicable guidelines and standards.
 
-The "guidelines and standards" requirement could fill entire books and still lack a 100% clear definition, but rest assured that you will receive feedback if something is not right. That being said, please consult the [Spartacus Guidelines and Best Practices](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki/Spartacus-Guidelines-and-Best-Practices).
+The "guidelines and standards" requirement could fill entire books and still lack a 100% clear definition, but rest assured that you will receive feedback if something is not right. That being said, please consult the [Contributor's Guide](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/Contributors-Guide/).
 
 ### Contribution Process
 
@@ -178,7 +178,7 @@ The "guidelines and standards" requirement could fill entire books and still lac
 
 1. Build and run the storefront from the library development workspace. 
 
-    For more information, see [Contributor Setup](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki/Contributor-Setup).
+    For more information, see [Contributor Setup](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/Contributor-Setup/).
 
 1. Work on the change in your fork (either on the `develop` branch or on a feature branch).
 
@@ -186,7 +186,7 @@ The "guidelines and standards" requirement could fill entire books and still lac
 
     That you should also use the squash and merge feature when additional changes are required after code review.
 
-1. In the commit message, please follow the conventions described in the [Commit Message Guidelines](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki/Commit-Message-Guidelines).
+1. In the commit message, please follow the conventions described in [Committing Code to Spartacus](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/Commit-Guidelines/).
 
     By following the guidelines, your work will be accurately captured in the release changelog.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Spartacus is a lean, Angular-based JavaScript storefront for SAP Commerce Cloud. Spartacus talks to SAP Commerce Cloud exclusively through the Commerce REST API.
 
-- Documentation is currently hosted on our [wiki](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki).
+- Documentation is hosted on our dedicated [Spartacus Documentation site](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/).
 - Questions? Join our [Slack workspace](https://join.slack.com/t/spartacus-storefront/shared_invite/enQtNDM1OTI3OTMwNjU5LTRiNTFkMDJlZjRmYTBlY2QzZTM3YWNlYzJkYmEwZDY2MjM0MmIyYzdhYmQwZDMwZjg2YTAwOGFjNDBhZDYyNzE).
-- For details on the 1.0 launch, see the [Release 1.0 documentation](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki/Release-1.0-Information-and-Roadmap) in our wiki.
+- For details on the 1.0 launch, see the [Release 1.0 Information page](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/Release-1.0-Information/) on our Spartacus documentation site.
 
 Spartacus is...
 
@@ -31,7 +31,7 @@ Spartacus provides core storefront features such as:
 - Checkout
 - Order history
 
-See the [Release 1.0 documentation](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki/Release-1.0-Information-and-Roadmap) for more information.
+See the [Release 1.0 documentation](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/Release-1.0-Information/) for more information.
 
 
 
@@ -50,7 +50,7 @@ To get started with Spartacus, the recommended approach is to build your storefr
 
 Spartacus currently can only be used with a SAP Commerce Cloud instance through Commerce APIs. 
 
-For complete setup instructions, see the [Setup and Installation](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki/Setup-and-Installation) guide.
+For complete setup instructions, see the [Setup and Installation](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/Setup-and-Installation/) guide.
 
 
 
@@ -68,7 +68,7 @@ The documentation for customizing and extending Spartacus is still under develop
 
 # Limitations
 
-When 1.0 is released, it is recommended to use SAP Commerce 1905. Spartacus works with earlier versions of SAP Commerce Cloud, with limitations the farther back you go, mainly due to changes in OCC REST APIs. See the [Setup and Installation](https://github.com/SAP/cloud-commerce-spartacus-storefront/wiki/Setup-and-Installation) guide for more information. 
+When 1.0 is released, it is recommended to use SAP Commerce 1905. Spartacus works with earlier versions of SAP Commerce Cloud, with limitations the farther back you go, mainly due to changes in OCC REST APIs. See the [Setup and Installation](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/Setup-and-Installation/) guide for more information. 
 
 Spartacus is also being updated so that it works well with upcoming releases of SAP Commerce Cloud. This means that certain features of Spartacus may only work with unreleased future editions of SAP Commerce Cloud. This will be noted as we release new versions of Spartacus.
 


### PR DESCRIPTION
Update links in Readme.md and Contributing.md to point to new GitHub Pages documentation site.