### PR TITLE
Remove cxApi service from public api

### DIFF
--- a/projects/core/public_api.ts
+++ b/projects/core/public_api.ts
@@ -6,7 +6,6 @@ export * from './src/cart/index';
 export * from './src/checkout/index';
 export * from './src/cms/index';
 export * from './src/config/index';
-export * from './src/cx-api/index';
 export * from './src/global-message/index';
 export * from './src/i18n/index';
 export * from './src/kyma/index';

--- a/projects/core/src/cx-api/cx-api.module.ts
+++ b/projects/core/src/cx-api/cx-api.module.ts
@@ -1,4 +1,0 @@
-import { NgModule } from '@angular/core';
-
-@NgModule({})
-export class CxApiModule {}

--- a/projects/core/src/cx-api/index.ts
+++ b/projects/core/src/cx-api/index.ts
@@ -1,2 +1,0 @@
-export * from './cx-api.module';
-export * from './cx-api.service';

--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.spec.ts
@@ -18,10 +18,10 @@ import {
   CmsComponent,
   CmsService,
   CmsConfig,
-  CxApiService,
   ContentSlotComponentData,
   DynamicAttributeService,
 } from '@spartacus/core';
+import { CxApiService } from './cx-api.service';
 
 const testText = 'test text';
 

--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
@@ -17,11 +17,11 @@ import {
   CmsConfig,
   CmsService,
   ContentSlotComponentData,
-  CxApiService,
   DynamicAttributeService,
 } from '@spartacus/core';
 import { CmsComponentData } from '../model/cms-component-data';
 import { ComponentMapperService } from './component-mapper.service';
+import { CxApiService } from './cx-api.service';
 
 @Directive({
   selector: '[cxComponentWrapper]',

--- a/projects/storefrontlib/src/cms-structure/page/component/cx-api.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/cx-api.service.spec.ts
@@ -1,16 +1,17 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
+import {
+  AuthService,
+  CmsService,
+  CurrencyService,
+  LanguageService,
+  ProductReviewService,
+  ProductSearchService,
+  ProductService,
+  RoutingService,
+  TranslationService,
+} from '@spartacus/core';
 
 import { CxApiService } from './cx-api.service';
-import { AuthService } from '../auth/index';
-import { CmsService } from '../cms/index';
-import { RoutingService } from '../routing/index';
-import { LanguageService, CurrencyService } from '../site-context/index';
-import {
-  ProductService,
-  ProductSearchService,
-  ProductReviewService,
-} from '../product/index';
-import { TranslationService } from '../i18n/translation.service';
 
 class MockAuthService {}
 class MockCmsService {}

--- a/projects/storefrontlib/src/cms-structure/page/component/cx-api.service.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/cx-api.service.ts
@@ -1,16 +1,17 @@
 import { Injectable, Optional } from '@angular/core';
-
-import { AuthService } from '../auth/index';
-import { CmsService } from '../cms/index';
-import { RoutingService } from '../routing/index';
-import { LanguageService, CurrencyService } from '../site-context/index';
 import {
+  AuthService,
+  CmsService,
+  RoutingService,
+  CurrencyService,
+  LanguageService,
+  BaseSiteService,
   ProductService,
   ProductSearchService,
   ProductReviewService,
-} from '../product/index';
-import { UserService } from '../user/index';
-import { TranslationService } from '../i18n/index';
+  UserService,
+  TranslationService,
+} from '@spartacus/core';
 
 @Injectable({
   providedIn: 'root',
@@ -23,6 +24,7 @@ export class CxApiService {
     // site context
     @Optional() public currency: CurrencyService,
     @Optional() public language: LanguageService,
+    @Optional() public baseSite: BaseSiteService,
     // product
     @Optional() public product: ProductService,
     @Optional() public productSearch: ProductSearchService,


### PR DESCRIPTION
cxApi service is used to provide api to cms web components implementation, which is experimental at the moment, and should not be exposed as a general usage service.

Closes GH-3425