### PR TITLE
[WIP] fix: Drop cart data on 'notFound' error

### DIFF
--- a/projects/assets/src/translations/en/common.ts
+++ b/projects/assets/src/translations/en/common.ts
@@ -88,6 +88,7 @@ export const common = {
       },
     },
     cartNotFound: 'Cart not found.',
+    cartRefreshed: 'Cart refreshed.',
   },
   miniCart: {
     item: '{{count}} item currently in your cart',

--- a/projects/core/src/cart/facade/cart.service.ts
+++ b/projects/core/src/cart/facade/cart.service.ts
@@ -33,16 +33,23 @@ export class CartService {
       this.store.select(CartSelectors.getCartContent),
       this.store.select(CartSelectors.getCartLoading),
       this.authService.getUserToken(),
+      this.store.select(CartSelectors.getCartLoaded),
     ]).pipe(
       // combineLatest emits multiple times on each property update instead of one emit
       // additionally dispatching actions that changes selectors used here needs to happen in order
       // for this asyncScheduler is used here
       debounceTime(1, asyncScheduler),
       filter(([, loading]) => !loading),
-      tap(([cart, , userToken]) => {
+      tap(([cart, , userToken, loaded]) => {
         if (this.isJustLoggedIn(userToken.userId)) {
           this.loadOrMerge();
         } else if (this.isCreated(cart) && this.isIncomplete(cart)) {
+          this.load();
+        } else if (
+          typeof userToken.userId !== 'undefined' &&
+          !this.isCreated(cart) &&
+          !loaded
+        ) {
           this.load();
         }
 

--- a/projects/core/src/cart/store/actions/cart.action.ts
+++ b/projects/core/src/cart/store/actions/cart.action.ts
@@ -15,6 +15,8 @@ export const MERGE_CART_SUCCESS = '[Cart] Merge Cart Success';
 
 export const RESET_CART_DETAILS = '[Cart] Reset Cart Details';
 
+export const CLEAR_CART = '[Cart] Clear Cart';
+
 export class CreateCart extends StateLoaderActions.LoaderLoadAction {
   readonly type = CREATE_CART;
   constructor(public payload: any) {
@@ -72,6 +74,13 @@ export class ResetCartDetails implements Action {
   constructor() {}
 }
 
+export class ClearCart extends StateLoaderActions.LoaderResetAction {
+  readonly type = CLEAR_CART;
+  constructor() {
+    super(CART_DATA);
+  }
+}
+
 export type CartAction =
   | CreateCart
   | CreateCartFail
@@ -81,4 +90,5 @@ export type CartAction =
   | LoadCartSuccess
   | MergeCart
   | MergeCartSuccess
-  | ResetCartDetails;
+  | ResetCartDetails
+  | ClearCart;

--- a/projects/core/src/cart/store/effects/cart.effect.ts
+++ b/projects/core/src/cart/store/effects/cart.effect.ts
@@ -17,7 +17,9 @@ import { CartActions } from '../actions/index';
 export class CartEffects {
   @Effect()
   loadCart$: Observable<
-    CartActions.LoadCartFail | CartActions.LoadCartSuccess
+    | CartActions.LoadCartFail
+    | CartActions.LoadCartSuccess
+    | CartActions.ClearCart
   > = this.actions$.pipe(
     ofType(CartActions.LOAD_CART),
     map(

--- a/projects/core/src/cart/store/reducers/cart.reducer.ts
+++ b/projects/core/src/cart/store/reducers/cart.reducer.ts
@@ -87,6 +87,10 @@ export function reducer(
         cartMergeComplete: false,
       };
     }
+
+    case CartActions.CLEAR_CART: {
+      return initialState;
+    }
   }
 
   return state;

--- a/projects/core/src/global-message/http-interceptors/handlers/bad-request.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/bad-request.handler.ts
@@ -1,10 +1,10 @@
 import { HttpErrorResponse, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Translatable } from '../../../i18n/translatable';
+import { ErrorModel } from '../../../model/misc.model';
 import { GlobalMessageType } from '../../models/global-message.model';
 import { HttpResponseStatus } from '../../models/response-status.model';
 import { HttpErrorHandler } from './http-error.handler';
-import { ErrorModel } from '../../../model/misc.model';
-import { Translatable } from '../../../i18n/translatable';
 
 const OAUTH_ENDPOINT = '/authorizationserver/oauth/token';
 
@@ -50,7 +50,8 @@ export class BadRequestHandler extends HttpErrorHandler {
             error.subjectType === 'cart' &&
             error.reason === 'notFound'
           ) {
-            errorMessage = { key: 'httpHandlers.cartNotFound' };
+            // for cart not found we provide better message in cart effects
+            return;
           } else if (error.type === 'ValidationError') {
             // build translation key in case of backend field validation error
             errorMessage = {


### PR DESCRIPTION
Work in progress. This change introduces breaking changes. We could avoid those, but then the UX would not be that good.

Behavior change is needed, so some breaking changes we can't avoid.

We can avoid changes in bad request handler and new service in cart effect constructor.

Closes #3431 