### PR TITLE
fix: Prevent infinite loop on cart not found error

### DIFF
--- a/projects/core/src/cart/store/actions/cart.action.spec.ts
+++ b/projects/core/src/cart/store/actions/cart.action.spec.ts
@@ -113,5 +113,38 @@ describe('Cart Actions', () => {
         });
       });
     });
+    describe('MergeCartSuccess', () => {
+      it('should create the action', () => {
+        const userId = 'xxx@xxx.xxx';
+        const cartId = 'testCartId';
+        const action = new CartActions.MergeCartSuccess({
+          userId: userId,
+          cartId: cartId,
+        });
+        expect({ ...action }).toEqual({
+          type: CartActions.MERGE_CART_SUCCESS,
+          payload: { userId, cartId },
+        });
+      });
+    });
+  });
+
+  describe('ResetCartDetails', () => {
+    it('should create the action', () => {
+      const action = new CartActions.ResetCartDetails();
+      expect({ ...action }).toEqual({
+        type: CartActions.RESET_CART_DETAILS,
+      });
+    });
+  });
+
+  describe('ClearCart', () => {
+    it('should create the action', () => {
+      const action = new CartActions.ClearCart();
+      expect({ ...action }).toEqual({
+        type: CartActions.CLEAR_CART,
+        meta: StateLoaderActions.resetMeta(CART_DATA),
+      });
+    });
   });
 });

--- a/projects/core/src/cart/store/actions/cart.action.ts
+++ b/projects/core/src/cart/store/actions/cart.action.ts
@@ -15,6 +15,8 @@ export const MERGE_CART_SUCCESS = '[Cart] Merge Cart Success';
 
 export const RESET_CART_DETAILS = '[Cart] Reset Cart Details';
 
+export const CLEAR_CART = '[Cart] Clear Cart';
+
 export class CreateCart extends StateLoaderActions.LoaderLoadAction {
   readonly type = CREATE_CART;
   constructor(public payload: any) {
@@ -72,6 +74,13 @@ export class ResetCartDetails implements Action {
   constructor() {}
 }
 
+export class ClearCart extends StateLoaderActions.LoaderResetAction {
+  readonly type = CLEAR_CART;
+  constructor() {
+    super(CART_DATA);
+  }
+}
+
 export type CartAction =
   | CreateCart
   | CreateCartFail
@@ -81,4 +90,5 @@ export type CartAction =
   | LoadCartSuccess
   | MergeCart
   | MergeCartSuccess
-  | ResetCartDetails;
+  | ResetCartDetails
+  | ClearCart;

--- a/projects/core/src/cart/store/effects/cart.effect.spec.ts
+++ b/projects/core/src/cart/store/effects/cart.effect.spec.ts
@@ -34,16 +34,10 @@ const testCart: Cart = {
   },
 };
 
-const loadMock = createSpy().and.returnValue(of(testCart));
-
-class MockCartConnector {
-  create = createSpy().and.returnValue(of(testCart));
-  load = loadMock;
-}
-
 describe('Cart effect', () => {
   let cartEffects: fromEffects.CartEffects;
   let actions$: Observable<any>;
+  let loadMock: jasmine.Spy;
 
   const MockOccModuleConfig: OccConfig = {
     backend: {
@@ -58,6 +52,13 @@ describe('Cart effect', () => {
   const cartId = 'testCartId';
 
   beforeEach(() => {
+    loadMock = createSpy().and.returnValue(of(testCart));
+
+    class MockCartConnector {
+      create = createSpy().and.returnValue(of(testCart));
+      load = loadMock;
+    }
+
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -125,8 +126,6 @@ describe('Cart effect', () => {
       actions$ = hot('-a', { a: action });
       const expected = cold('-b', { b: completion });
       expect(cartEffects.loadCart$).toBeObservable(expected);
-      // restore previous mock
-      loadMock.and.returnValue(of(testCart));
     });
   });
 

--- a/projects/core/src/cart/store/effects/cart.effect.ts
+++ b/projects/core/src/cart/store/effects/cart.effect.ts
@@ -40,7 +40,6 @@ export class CartEffects {
             return new CartActions.LoadCartSuccess(cart);
           }),
           catchError(error => {
-            of(new CartActions.LoadCartFail(makeErrorSerializable(error)));
             if (error && error.error && error.error.errors) {
               const cartNotFoundErrors = error.error.errors.filter(
                 err => err.reason === 'notFound'

--- a/projects/core/src/cart/store/reducers/cart.reducer.spec.ts
+++ b/projects/core/src/cart/store/reducers/cart.reducer.spec.ts
@@ -13,7 +13,28 @@ describe('Cart reducer', () => {
     });
   });
 
-  describe('CREATE_CART_SUCCESSS or LOAD_CART_SUCCESS action', () => {
+  describe('MERGE_CART action', () => {
+    it('should set cartMergeComplete flag to false', () => {
+      const { initialState } = fromCart;
+      const action = new CartActions.MergeCart({});
+      const state = fromCart.reducer(initialState, action);
+
+      expect(state.cartMergeComplete).toEqual(false);
+    });
+  });
+
+  describe('MERGE_CART_SUCCESS action', () => {
+    it('should set cartMergeComplete and refresh flag to true ', () => {
+      const { initialState } = fromCart;
+      const action = new CartActions.MergeCartSuccess({});
+      const state = fromCart.reducer(initialState, action);
+
+      expect(state.cartMergeComplete).toEqual(true);
+      expect(state.refresh).toEqual(true);
+    });
+  });
+
+  describe('CREATE_CART_SUCCESS or LOAD_CART_SUCCESS action', () => {
     it('should create an empty cart', () => {
       const testCart: Cart = {
         code: 'xxx',
@@ -69,13 +90,65 @@ describe('Cart reducer', () => {
     });
   });
 
-  describe('REMOVE_ENTRY_SUCCESS or ADD_ENTRY_SUCCESS action', () => {
+  describe('REMOVE_ENTRY_SUCCESS action', () => {
+    it('should set refresh to true', () => {
+      const { initialState } = fromCart;
+
+      const action = new CartActions.CartRemoveEntrySuccess({});
+      const state = fromCart.reducer(initialState, action);
+      expect(state.refresh).toEqual(true);
+    });
+  });
+
+  describe('ADD_ENTRY_SUCCESS action', () => {
     it('should set refresh to true', () => {
       const { initialState } = fromCart;
 
       const action = new CartActions.CartAddEntrySuccess({});
       const state = fromCart.reducer(initialState, action);
       expect(state.refresh).toEqual(true);
+    });
+  });
+
+  describe('UPDATE_ENTRY_SUCCESS action', () => {
+    it('should set refresh to true', () => {
+      const { initialState } = fromCart;
+
+      const action = new CartActions.CartUpdateEntrySuccess({});
+      const state = fromCart.reducer(initialState, action);
+      expect(state.refresh).toEqual(true);
+    });
+  });
+
+  describe('RESET_CART_DETAILS', () => {
+    it('should reset state apart from code and guid', () => {
+      const { initialState } = fromCart;
+      const guid = 'guid';
+      const code = 'code';
+      const modifiedState = { ...initialState, content: { code, guid } };
+      const action = new CartActions.ResetCartDetails();
+      const state = fromCart.reducer(modifiedState, action);
+      expect(state.refresh).toEqual(false);
+      expect(state.cartMergeComplete).toEqual(false);
+      expect(state.entries).toEqual({});
+      expect(state.content).toEqual({
+        guid,
+        code,
+      });
+    });
+  });
+
+  describe('CLEAR_CART', () => {
+    it('should reset state', () => {
+      const { initialState } = fromCart;
+      const modifiedState = {
+        ...initialState,
+        refresh: true,
+        cartMergeComplete: true,
+      };
+      const action = new CartActions.ClearCart();
+      const state = fromCart.reducer(modifiedState, action);
+      expect(state).toEqual(initialState);
     });
   });
 });

--- a/projects/core/src/cart/store/reducers/cart.reducer.ts
+++ b/projects/core/src/cart/store/reducers/cart.reducer.ts
@@ -87,6 +87,10 @@ export function reducer(
         cartMergeComplete: false,
       };
     }
+
+    case CartActions.CLEAR_CART: {
+      return initialState;
+    }
   }
 
   return state;

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/reset-password/reset-password.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/reset-password/reset-password.e2e-spec.ts
@@ -2,7 +2,7 @@ context('Reset Password Page', () => {
   beforeEach(() => {
     // Clear the session to make sure no user is authenticated.
     cy.window().then(win => win.sessionStorage.clear());
-    cy.visit('/login/reset-password');
+    cy.visit('/login/pw/change');
   });
 
   it('should not submit an empty form', () => {
@@ -12,7 +12,7 @@ context('Reset Password Page', () => {
     cy.get('cx-reset-password-form form').within(() => {
       cy.get('button[type="submit"]').click();
     });
-    cy.url().should('match', /\/login\/reset-password$/);
+    cy.url().should('match', /\/login\/pw\/change$/);
     cy.get('cx-global-message .alert').should('not.exist');
   });
 
@@ -24,7 +24,7 @@ context('Reset Password Page', () => {
       cy.get('[formcontrolname="repassword"]').type('N3wPassword!');
       cy.get('button[type="submit"]').click();
     });
-    cy.url().should('match', /\/login\/reset-password$/);
+    cy.url().should('match', /\/login\/pw\/change$/);
     cy.get('cx-global-message .alert-danger').should('exist');
   });
 


### PR DESCRIPTION
Error "Cart not found" will still be displayed. It will be shown once.
Apart from the fix for infinite loop and wrote some unit tests for code that wasn't cover by existing tests.

Extra PR for this issue will include some UX improvement for handling cart between devices but introduces breaking changes.

The behavior of cart in this PR:
- create cart on one device
- login on another device to the same account (you get the same cart as on another device)

Another use case, where you end up with separate carts on each device:
- complete order on one device (cart no longer exists)
- login on another device
- add something to cart on each device
- on each device, you have a different cart


Closes #3478 