### PR TITLE
feat: disable suffix routes by config 

### DIFF
--- a/projects/storefrontlib/src/cms-pages/product-details-page/product-details-page.module.ts
+++ b/projects/storefrontlib/src/cms-pages/product-details-page/product-details-page.module.ts
@@ -22,6 +22,7 @@ import { suffixUrlMatcher } from '../../cms-structure/routing/suffix-routes/suff
             marker: 'p',
             paramName: 'productCode',
           },
+          cxSuffixRoute: 'product',
         },
       },
     ]),

--- a/projects/storefrontlib/src/cms-pages/product-listing-page/product-listing-page.module.ts
+++ b/projects/storefrontlib/src/cms-pages/product-listing-page/product-listing-page.module.ts
@@ -32,6 +32,7 @@ import { suffixUrlMatcher } from '../../cms-structure/routing/suffix-routes/suff
             marker: 'c',
             paramName: 'categoryCode',
           },
+          cxSuffixRoute: 'category',
         },
       },
     ]),

--- a/projects/storefrontlib/src/cms-structure/routing/index.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/index.ts
@@ -1,1 +1,2 @@
 export * from './cms-route/index';
+export * from './suffix-routes/index';

--- a/projects/storefrontlib/src/cms-structure/routing/routing.module.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/routing.module.ts
@@ -5,9 +5,10 @@ import {
 } from '@spartacus/core';
 import { CmsRouteModule } from './cms-route/cms-route.module';
 import { defaultRoutingConfig } from './default-routing-config';
+import { SuffixRoutesModule } from './suffix-routes/suffix-routes.module';
 
 @NgModule({
-  imports: [CoreRoutingModule.forRoot(), CmsRouteModule],
+  imports: [CoreRoutingModule.forRoot(), CmsRouteModule, SuffixRoutesModule],
 })
 export class RoutingModule {
   static forRoot(): ModuleWithProviders<RoutingModule> {

--- a/projects/storefrontlib/src/cms-structure/routing/suffix-routes/index.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/suffix-routes/index.ts
@@ -1,0 +1,3 @@
+export * from './suffix-routes-config';
+export { SuffixRoutesModule } from './suffix-routes.module';
+export * from './suffix-routes.service';

--- a/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes-config.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes-config.ts
@@ -1,0 +1,12 @@
+export interface SuffixRouteConfig {
+  disabled?: boolean;
+}
+
+export abstract class SuffixRoutesConfig {
+  routing?: {
+    suffixRoutes?: {
+      product?: SuffixRouteConfig;
+      category?: SuffixRouteConfig;
+    };
+  };
+}

--- a/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes.module.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes.module.ts
@@ -1,0 +1,24 @@
+import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { Config } from '@spartacus/core';
+import { SuffixRoutesConfig } from './suffix-routes-config';
+import { SuffixRoutesService } from './suffix-routes.service';
+
+export function initSuffixRoutesService(
+  service: SuffixRoutesService
+): () => void {
+  const result = () => service.init();
+  return result;
+}
+
+@NgModule({
+  providers: [
+    { provide: SuffixRoutesConfig, useExisting: Config },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initSuffixRoutesService,
+      multi: true,
+      deps: [SuffixRoutesService],
+    },
+  ],
+})
+export class SuffixRoutesModule {}

--- a/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes.service.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { SuffixRoutesConfig } from './suffix-routes-config';
+import { SuffixRoutesService } from './suffix-routes.service';
+
+describe('SuffixRoutesService', () => {
+  let service: SuffixRoutesService;
+  let config: SuffixRoutesConfig;
+  let router: Router;
+
+  beforeEach(() => {
+    const mockConfig = { routing: { suffixRoutes: {} } };
+    class MockRouter {
+      config = [
+        { data: { cxRoute: 'product' } },
+        { data: { cxSuffixRoute: 'product' } },
+        { data: { cxSuffixRoute: 'category' } },
+      ];
+
+      resetConfig(routes) {
+        this.config = routes;
+      }
+    }
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: SuffixRoutesConfig, useValue: mockConfig },
+        { provide: Router, useClass: MockRouter },
+      ],
+    });
+
+    service = TestBed.get(SuffixRoutesService);
+    router = TestBed.get(Router);
+    config = TestBed.get(SuffixRoutesConfig);
+  });
+
+  it('should inject service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should not disable suffix routes if not configured so', () => {
+    service.init();
+    expect(router.config).toEqual([
+      { data: { cxRoute: 'product' } },
+      { data: { cxSuffixRoute: 'product' } },
+      { data: { cxSuffixRoute: 'category' } },
+    ]);
+  });
+
+  it('should disable only suffix routes that were disabled by config, but not standard routes', () => {
+    config.routing.suffixRoutes.product = { disabled: true };
+    service.init();
+    expect(router.config).toEqual([
+      { data: { cxRoute: 'product' } },
+      { data: { cxSuffixRoute: 'product' }, matcher: jasmine.any(Function) },
+      { data: { cxSuffixRoute: 'category' } },
+    ]);
+    expect(router.config[1].matcher(null, null, null)).toBe(null);
+  });
+
+  it('should disable all suffix routes that were disabled by config', () => {
+    config.routing.suffixRoutes = {
+      product: { disabled: true },
+      category: { disabled: true },
+    };
+    service.init();
+    expect(router.config).toEqual([
+      { data: { cxRoute: 'product' } },
+      { data: { cxSuffixRoute: 'product' }, matcher: jasmine.any(Function) },
+      { data: { cxSuffixRoute: 'category' }, matcher: jasmine.any(Function) },
+    ]);
+    expect(router.config[1].matcher(null, null, null)).toBe(null);
+    expect(router.config[2].matcher(null, null, null)).toBe(null);
+  });
+});

--- a/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes.service.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/suffix-routes/suffix-routes.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, Injector } from '@angular/core';
+import { Route, Router, Routes } from '@angular/router';
+import { SuffixRoutesConfig } from './suffix-routes-config';
+
+@Injectable({ providedIn: 'root' })
+export class SuffixRoutesService {
+  constructor(private injector: Injector, private config: SuffixRoutesConfig) {}
+
+  init() {
+    const router = this.injector.get(Router);
+    const newRoutes = this.disableRoutesByConfig(router.config);
+    router.resetConfig(newRoutes);
+  }
+
+  private disableRoutesByConfig(routes: Routes): Routes {
+    return (routes || []).map(route => {
+      const name = this.getRouteName(route);
+      return name && this.shouldDisableRoute(name)
+        ? {
+            ...route,
+            matcher: () => null,
+          }
+        : route;
+    });
+  }
+
+  private getRouteName(route: Route): string {
+    return route.data && route.data.cxSuffixRoute;
+  }
+
+  private shouldDisableRoute(routeName: string): boolean {
+    return (
+      this.config &&
+      this.config.routing &&
+      this.config.routing.suffixRoutes &&
+      this.config.routing.suffixRoutes[routeName] &&
+      this.config.routing.suffixRoutes[routeName].disabled
+    );
+  }
+}

--- a/projects/storefrontlib/src/storefront-config.ts
+++ b/projects/storefrontlib/src/storefront-config.ts
@@ -13,6 +13,7 @@ import {
 import { CheckoutConfig } from './cms-components/checkout/config/checkout-config';
 import { IconConfig } from './cms-components/misc/icon/index';
 import { PWAModuleConfig } from './cms-structure/pwa/index';
+import { SuffixRoutesConfig } from './cms-structure/routing/suffix-routes/suffix-routes-config';
 import { LayoutConfig } from './layout/config/layout-config';
 
 export type StorefrontConfig =
@@ -24,6 +25,7 @@ export type StorefrontConfig =
   | SiteContextConfig
   | LayoutConfig
   | RoutingConfig
+  | SuffixRoutesConfig
   | I18nConfig
   | PersonalizationConfig
   | IconConfig


### PR DESCRIPTION
In #1978 we implemented special suffix routes **/p/:productCode and **/c/:categoryCode which were not configurable and hard to opt out (it required decomposing StorefrontModule). Now you can disable specific suffix routes by config, i.e.:
```
     routing: {
        suffixRoutes: {
          category: { disabled: true },
          product: { disabled: true },
        },
      }
```

close GH-3523