### PR TITLE
Revert "GH-3687: Support billing addresses with a country that has no regions."

### DIFF
--- a/projects/core/src/occ/adapters/checkout/occ-checkout-payment.adapter.spec.ts
+++ b/projects/core/src/occ/adapters/checkout/occ-checkout-payment.adapter.spec.ts
@@ -465,56 +465,5 @@ describe('OccCheckoutPaymentAdapter', () => {
       httpMock.expectOne('/cardtypes').flush({});
       expect(converter.pipeableMany).toHaveBeenCalledWith(CARD_TYPE_NORMALIZER);
     });
-
-    describe('getParamsForPaymentProvider() function ', () => {
-      const parametersSentByBackend = [
-        { key: 'billTo_country', value: 'CA' },
-        { key: 'billTo_state', value: 'QC' },
-      ];
-      const labelsMap = {
-        hybris_billTo_country: 'billTo_country',
-        hybris_billTo_region: 'billTo_state',
-      };
-
-      it('should support billing address in a different country than the default/shipping address.', () => {
-        const paymentDetails: PaymentDetails = {
-          cardType: { code: 'visa' },
-          billingAddress: {
-            country: { isocode: 'US' },
-            region: { isocodeShort: 'RG' },
-          },
-        };
-        const params = service['getParamsForPaymentProvider'](
-          paymentDetails,
-          parametersSentByBackend,
-          labelsMap
-        );
-        expect(params['billTo_country']).toEqual(
-          paymentDetails.billingAddress.country.isocode
-        );
-        expect(params['billTo_state']).toEqual(
-          paymentDetails.billingAddress.region.isocodeShort
-        );
-      });
-
-      it('should support billing address different than shipping when billing country has no region.', () => {
-        const paymentDetails: PaymentDetails = {
-          cardType: { code: 'visa' },
-          billingAddress: {
-            country: { isocode: 'PL' },
-          },
-        };
-
-        const params = service['getParamsForPaymentProvider'](
-          paymentDetails,
-          parametersSentByBackend,
-          labelsMap
-        );
-        expect(params['billTo_country']).toEqual(
-          paymentDetails.billingAddress.country.isocode
-        );
-        expect(params['billTo_state']).toEqual('');
-      });
-    });
   });
 });

--- a/projects/core/src/occ/adapters/checkout/occ-checkout-payment.adapter.ts
+++ b/projects/core/src/occ/adapters/checkout/occ-checkout-payment.adapter.ts
@@ -189,8 +189,6 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
     if (paymentDetails.billingAddress.region) {
       params[mappingLabels['hybris_billTo_region']] =
         paymentDetails.billingAddress.region.isocodeShort;
-    } else {
-      params[mappingLabels['hybris_billTo_region']] = '';
     }
     params[mappingLabels['hybris_billTo_postalcode']] =
       paymentDetails.billingAddress.postalCode;


### PR DESCRIPTION
This reverts commit 99e998a80254e14274b37e47fe6b993f1f7d734d.

PR: https://github.com/SAP/cloud-commerce-spartacus-storefront/pull/3712

Issue Ticket: #3687