### PR TITLE
Revert commits with exclusion mechanism for syncing with browser storage

### DIFF
--- a/projects/core/src/auth/store/auth-store.module.ts
+++ b/projects/core/src/auth/store/auth-store.module.ts
@@ -16,10 +16,12 @@ export function authStoreConfigFactory(): StateConfig {
     state: {
       storageSync: {
         keys: {
-          'auth.userToken.token': StorageSyncType.LOCAL_STORAGE,
-        },
-        excludeKeys: {
-          'auth.userToken.token.refresh_token': StorageSyncType.LOCAL_STORAGE,
+          'auth.userToken.token.access_token': StorageSyncType.LOCAL_STORAGE,
+          'auth.userToken.token.token_type': StorageSyncType.LOCAL_STORAGE,
+          'auth.userToken.token.expires_in': StorageSyncType.LOCAL_STORAGE,
+          'auth.userToken.token.expiration_time': StorageSyncType.LOCAL_STORAGE,
+          'auth.userToken.token.scope': StorageSyncType.LOCAL_STORAGE,
+          'auth.userToken.token.userId': StorageSyncType.LOCAL_STORAGE,
         },
       },
     },

--- a/projects/core/src/kyma/store/kyma-store.module.ts
+++ b/projects/core/src/kyma/store/kyma-store.module.ts
@@ -18,9 +18,6 @@ export function kymaStoreConfigFactory(): StateConfig {
         keys: {
           'kyma.openIdToken.value': StorageSyncType.LOCAL_STORAGE,
         },
-        excludeKeys: {
-          'kyma.openIdToken.value.refresh_token': StorageSyncType.LOCAL_STORAGE,
-        },
       },
     },
   };

--- a/projects/core/src/state/config/default-state-config.ts
+++ b/projects/core/src/state/config/default-state-config.ts
@@ -9,7 +9,6 @@ export const defaultStateConfig: StateConfig = {
       localStorageKeyName: DEFAULT_LOCAL_STORAGE_KEY,
       sessionStorageKeyName: DEFAULT_SESSION_STORAGE_KEY,
       keys: {},
-      excludeKeys: {},
     },
   },
 };

--- a/projects/core/src/state/config/state-config.ts
+++ b/projects/core/src/state/config/state-config.ts
@@ -27,12 +27,6 @@ export abstract class StateConfig {
       keys?: {
         [key: string]: StorageSyncType;
       };
-      /**
-       * A set of keys not to sync with the specified browser's storage.
-       */
-      excludeKeys?: {
-        [key: string]: StorageSyncType;
-      };
     };
     ssrTransfer?: {
       keys?: {

--- a/projects/core/src/state/reducers/storage-sync.reducer.spec.ts
+++ b/projects/core/src/state/reducers/storage-sync.reducer.spec.ts
@@ -63,13 +63,6 @@ describe('storage-sync-reducer', () => {
               access_token: StorageSyncType.SESSION_STORAGE,
               refresh_token: StorageSyncType.LOCAL_STORAGE,
               do_not_sync: StorageSyncType.NO_STORAGE,
-              user: StorageSyncType.SESSION_STORAGE,
-            },
-            excludeKeys: {
-              'user.account.details.currency.name':
-                StorageSyncType.SESSION_STORAGE,
-              'user.account.details.currency.symbol':
-                StorageSyncType.SESSION_STORAGE,
             },
           },
         },
@@ -100,7 +93,7 @@ describe('storage-sync-reducer', () => {
     });
 
     describe('when the action type is NOT UPDATE nor INIT', () => {
-      it('should set the configured keys to the configured storage', () => {
+      it('should set the configured keys to configured storage', () => {
         spyOn(sessionStorageMock, 'getItem').and.returnValue('"xxx"');
         spyOn(localStorageMock, 'getItem').and.returnValue('"yyy"');
 
@@ -124,50 +117,6 @@ describe('storage-sync-reducer', () => {
           DEFAULT_LOCAL_STORAGE_KEY,
           JSON.stringify({
             refresh_token: 'yyy',
-          })
-        );
-      });
-
-      it('should set the configured keys to the configured storage and exclude specified keys', () => {
-        const state = {
-          user: {
-            account: {
-              addresses: {
-                loading: false,
-              },
-              details: {
-                currency: {
-                  name: 'CAD',
-                  symbol: '$',
-                  value: 100,
-                },
-              },
-            },
-          },
-        };
-        spyOn(sessionStorageMock, 'getItem').and.returnValue(
-          JSON.stringify(state)
-        );
-        spyOn(sessionStorageMock, 'setItem').and.stub();
-
-        const result = reducer(state, { type: 'AN-ACTION' });
-        // excluded keys are not stored in the storage, but they're present in the state
-        expect(result).toEqual(state);
-        expect(sessionStorageMock.setItem).toHaveBeenCalledWith(
-          DEFAULT_SESSION_STORAGE_KEY,
-          JSON.stringify({
-            user: {
-              account: {
-                addresses: {
-                  loading: false,
-                },
-                details: {
-                  currency: {
-                    value: 100,
-                  },
-                },
-              },
-            },
           })
         );
       });
@@ -274,13 +223,6 @@ describe('storage-sync-reducer', () => {
       d: StorageSyncType.SESSION_STORAGE,
       dj: StorageSyncType.NO_STORAGE,
     };
-
-    describe('when null is provided instead of keys', () => {
-      it('should return an empty array', () => {
-        const result = getKeysForStorage(null, StorageSyncType.NO_STORAGE);
-        expect(result).toEqual([]);
-      });
-    });
 
     it('should return two keys for local storage', () => {
       const result = getKeysForStorage(keys, StorageSyncType.LOCAL_STORAGE);

--- a/projects/core/src/state/reducers/storage-sync.reducer.ts
+++ b/projects/core/src/state/reducers/storage-sync.reducer.ts
@@ -35,15 +35,7 @@ export function getStorageSyncReducer<T>(
           storageSyncConfig.keys,
           StorageSyncType.LOCAL_STORAGE
         );
-        const localStorageExclusionKeys = getKeysForStorage(
-          storageSyncConfig.excludeKeys,
-          StorageSyncType.LOCAL_STORAGE
-        );
-        const localStorageStateSlices = getStateSlice(
-          localStorageKeys,
-          localStorageExclusionKeys,
-          state
-        );
+        const localStorageStateSlices = getStateSlice(localStorageKeys, state);
         persistToStorage(
           config.state.storageSync.localStorageKeyName,
           localStorageStateSlices,
@@ -55,13 +47,8 @@ export function getStorageSyncReducer<T>(
           storageSyncConfig.keys,
           StorageSyncType.SESSION_STORAGE
         );
-        const sessionStorageExclusionKeys = getKeysForStorage(
-          storageSyncConfig.excludeKeys,
-          StorageSyncType.SESSION_STORAGE
-        );
         const sessionStorageStateSlices = getStateSlice(
           sessionStorageKeys,
-          sessionStorageExclusionKeys,
           state
         );
         persistToStorage(
@@ -80,9 +67,6 @@ export function getKeysForStorage(
   keys: { [key: string]: StorageSyncType },
   storageType: StorageSyncType
 ): string[] {
-  if (!keys) {
-    return [];
-  }
   return Object.keys(keys).filter(key => keys[key] === storageType);
 }
 

--- a/projects/core/src/state/reducers/transfer-state.reducer.ts
+++ b/projects/core/src/state/reducers/transfer-state.reducer.ts
@@ -48,7 +48,7 @@ export function getServerTransferStateReducer(
     return function(state, action: any) {
       const newState = reducer(state, action);
       if (newState) {
-        const stateSlice = getStateSlice(Object.keys(keys), [], newState);
+        const stateSlice = getStateSlice(Object.keys(keys), newState);
         transferState.set(CX_KEY, stateSlice);
       }
 
@@ -75,11 +75,7 @@ export function getBrowserTransferStateReducer(
 
         if (!isLoggedIn && transferState.hasKey(CX_KEY)) {
           const cxKey = transferState.get(CX_KEY, {});
-          const transferredStateSlice = getStateSlice(
-            Object.keys(keys),
-            [],
-            cxKey
-          );
+          const transferredStateSlice = getStateSlice(Object.keys(keys), cxKey);
 
           state = deepMerge({}, state, transferredStateSlice);
         }

--- a/projects/core/src/state/utils/get-state-slice.spec.ts
+++ b/projects/core/src/state/utils/get-state-slice.spec.ts
@@ -1,9 +1,7 @@
 import {
   createShellObject,
-  getExclusionKeys,
   getStateSlice,
   getStateSliceValue,
-  handleExclusions,
 } from './get-state-slice';
 
 describe('state slice functions', () => {
@@ -45,17 +43,17 @@ describe('state slice functions', () => {
   describe('createShellObject', () => {
     describe('when no key is provided', () => {
       it('should return an empty object', () => {
-        expect(createShellObject('', [], { test: 'test' })).toEqual({});
+        expect(createShellObject('', { test: 'test' })).toEqual({});
       });
     });
     describe('when no value is provided', () => {
       it('should return an empty object', () => {
-        expect(createShellObject('key', [], undefined)).toEqual({});
+        expect(createShellObject('key', undefined)).toEqual({});
       });
     });
     describe('when an empty object is provided as a value', () => {
       it('should return an empty object', () => {
-        expect(createShellObject('', [], {})).toEqual({});
+        expect(createShellObject('', {})).toEqual({});
       });
     });
 
@@ -64,7 +62,7 @@ describe('state slice functions', () => {
         const key = 'test';
         const value = 'value';
 
-        const result = createShellObject(key, [], value);
+        const result = createShellObject(key, value);
         expect(result).toEqual({
           test: value,
         });
@@ -75,7 +73,7 @@ describe('state slice functions', () => {
         const key = 'a.b';
         const value = 'value';
 
-        const result = createShellObject(key, [], value);
+        const result = createShellObject(key, value);
         expect(result).toEqual({
           a: {
             b: value,
@@ -88,34 +86,12 @@ describe('state slice functions', () => {
         const key = 'a.b.v.g';
         const value = 'value';
 
-        const result = createShellObject(key, [], value);
+        const result = createShellObject(key, value);
         expect(result).toEqual({
           a: {
             b: {
               v: {
                 g: value,
-              },
-            },
-          },
-        });
-      });
-    });
-    describe('when exclusion keys are provided', () => {
-      it('should exclude the specified properties', () => {
-        const value = {
-          access_token: 'xxx',
-          refresh_token: 'yyy',
-        };
-        const result = createShellObject(
-          'auth.userToken.token',
-          ['auth.userToken.token.refresh_token'],
-          value
-        );
-        expect(result).toEqual({
-          auth: {
-            userToken: {
-              token: {
-                access_token: 'xxx',
               },
             },
           },
@@ -133,7 +109,7 @@ describe('state slice functions', () => {
       };
 
       const keys = ['products'];
-      const result = getStateSlice(keys, [], state);
+      const result = getStateSlice(keys, state);
 
       const expected = { products: state.products };
       expect(result).toEqual(expected);
@@ -147,7 +123,7 @@ describe('state slice functions', () => {
       };
 
       const keys = ['cms.pages'];
-      const result = getStateSlice(keys, [], state);
+      const result = getStateSlice(keys, state);
 
       const expected = {
         cms: { pages: state.cms.pages },
@@ -163,7 +139,7 @@ describe('state slice functions', () => {
       };
 
       const keys = ['cms.pages.page1'];
-      const result = getStateSlice(keys, [], state);
+      const result = getStateSlice(keys, state);
 
       const expected = { cms: { pages: { page1: state.cms.pages.page1 } } };
       expect(result).toEqual(expected);
@@ -177,7 +153,7 @@ describe('state slice functions', () => {
       };
 
       const keys = ['notPresent'];
-      const result = getStateSlice(keys, [], state);
+      const result = getStateSlice(keys, state);
 
       expect(result).toEqual({});
     });
@@ -210,7 +186,7 @@ describe('state slice functions', () => {
         'products.product1',
         'cms',
       ];
-      const result = getStateSlice(keys, [], state);
+      const result = getStateSlice(keys, state);
       expect(result).toEqual({
         user: {
           auth: {
@@ -260,7 +236,7 @@ describe('state slice functions', () => {
         'products.product1',
         'xxx',
       ];
-      const result = getStateSlice(keys, [], state);
+      const result = getStateSlice(keys, state);
       expect(result).toEqual({
         user: {
           auth: {
@@ -272,130 +248,6 @@ describe('state slice functions', () => {
         products: {
           product1: 'p1',
         },
-      });
-    });
-  });
-
-  describe('handleExclusions', () => {
-    const value = {
-      auth: {
-        userToken: {
-          token: {
-            access_token: 'xxx',
-            refresh_token: 'yyy',
-          },
-        },
-      },
-    };
-    describe('when there is nothing to exclude', () => {
-      it('should return the provided value', () => {
-        const result = handleExclusions(
-          'auth.userToken.token',
-          ['cart.token'],
-          value
-        );
-        expect(result).toEqual(value);
-      });
-    });
-    describe('when the removal condition is met', () => {
-      it('should remove the property that is one level deep', () => {
-        const result = handleExclusions(
-          'auth.userToken.token',
-          ['auth.userToken.token.refresh_token'],
-          value
-        );
-        expect(result).toEqual({
-          auth: {
-            userToken: {
-              token: {
-                access_token: 'xxx',
-              },
-            },
-          },
-        });
-      });
-
-      it('should remove the property that is a couple of levels deep', () => {
-        const userValue = {
-          user: {
-            account: {
-              details: {
-                currency: {
-                  symbol: '$',
-                  name: 'cad',
-                },
-              },
-            },
-            addresses: {
-              loading: false,
-            },
-          },
-        };
-        const result = handleExclusions(
-          'user',
-          ['user.account.details.currency.name'],
-          userValue
-        );
-        expect(result).toEqual({
-          user: {
-            account: {
-              details: {
-                currency: {
-                  symbol: '$',
-                },
-              },
-            },
-            addresses: {
-              loading: false,
-            },
-          },
-        } as any);
-      });
-    });
-  });
-
-  describe('getExclusionKeys', () => {
-    describe('when an invalid input is provided', () => {
-      it('should return an empty array', () => {
-        let result: string[];
-
-        result = getExclusionKeys(null, []);
-        expect(result).toEqual([]);
-
-        result = getExclusionKeys('', null);
-        expect(result).toEqual([]);
-
-        result = getExclusionKeys('', []);
-        expect(result).toEqual([]);
-      });
-    });
-
-    describe('when the provided key is NOT in at least one exclusion', () => {
-      it('should return an empty array', () => {
-        const result = getExclusionKeys('cart.token', [
-          'auth.userToken.token.refresh_token',
-        ]);
-        expect(result).toEqual([]);
-      });
-    });
-    describe('when the provided key is matched with one exclusion', () => {
-      it('should return one exclusion key', () => {
-        const result = getExclusionKeys('auth.userToken.token', [
-          'auth.userToken.token.refresh_token',
-        ]);
-        expect(result).toEqual(['auth.userToken.token.refresh_token']);
-      });
-    });
-    describe('when the provided key is matched with multiple exclusions', () => {
-      it('should return one exclusion key', () => {
-        const result = getExclusionKeys('auth.userToken.token', [
-          'auth.userToken.token.access_token',
-          'auth.userToken.token.refresh_token',
-        ]);
-        expect(result).toEqual([
-          'auth.userToken.token.access_token',
-          'auth.userToken.token.refresh_token',
-        ]);
       });
     });
   });

--- a/projects/core/src/state/utils/get-state-slice.ts
+++ b/projects/core/src/state/utils/get-state-slice.ts
@@ -1,93 +1,47 @@
 import { deepMerge } from '../../config/utils/deep-merge';
 
-const OBJECT_SEPARATOR = '.';
-
-export function getStateSliceValue(keys: string, state: any): any {
+export function getStateSliceValue<T, E>(keys: string, state: T): E {
   return keys
-    .split(OBJECT_SEPARATOR)
+    .split('.')
     .reduce(
       (previous, current) => (previous ? previous[current] : undefined),
       state
     );
 }
 
-export function createShellObject(
-  key: string,
-  excludeKeys: string[],
-  value: any
-): any {
+export function createShellObject<T, E>(key: string, value: T): E {
   if (!key || !value || Object.keys(value).length === 0) {
-    return {};
+    return {} as E;
   }
 
-  const shell = key.split(OBJECT_SEPARATOR).reduceRight((acc, previous) => {
-    return { [previous]: acc };
-  }, value);
-  return handleExclusions(key, excludeKeys, shell);
+  const keySplit = key.split('.');
+  const newObject = {};
+  let tempNewObject = newObject;
+
+  for (let i = 0; i < keySplit.length; i++) {
+    const currentKey = keySplit[i];
+    // last iteration
+    if (i === keySplit.length - 1) {
+      tempNewObject = tempNewObject[currentKey] = value;
+    } else {
+      tempNewObject = tempNewObject[currentKey] = {};
+    }
+  }
+
+  return newObject as E;
 }
 
-export function getStateSlice(
-  keys: string[],
-  excludeKeys: string[],
-  state: any
-): any {
+export function getStateSlice<T, E>(keys: string[], state: T): E {
   if (keys && keys.length === 0) {
-    return {};
+    return {} as E;
   }
 
   let stateSlices = {};
   for (const currentKey of keys) {
     const stateValue = getStateSliceValue(currentKey, state);
-    const shell = createShellObject(currentKey, excludeKeys, stateValue);
+    const shell = createShellObject(currentKey, stateValue);
     stateSlices = deepMerge(stateSlices, shell);
   }
 
-  return stateSlices;
-}
-
-export function handleExclusions(
-  key: string,
-  excludeKeys: string[],
-  value: any
-): any {
-  const exclusionKeys = getExclusionKeys(key, excludeKeys);
-  if (exclusionKeys.length === 0) {
-    return value;
-  }
-
-  const finalValue = deepMerge({}, value);
-  for (const currentExclusionKey of exclusionKeys) {
-    const exclusionChunksSplit = currentExclusionKey.split(OBJECT_SEPARATOR);
-
-    let nestedTemp = finalValue;
-    for (let i = 0; i < exclusionChunksSplit.length; i++) {
-      const currentChunk = exclusionChunksSplit[i];
-
-      // last iteration
-      if (i === exclusionChunksSplit.length - 1) {
-        if (nestedTemp && nestedTemp[currentChunk]) {
-          delete nestedTemp[currentChunk];
-        }
-      } else {
-        nestedTemp = nestedTemp[currentChunk];
-      }
-    }
-  }
-
-  return finalValue;
-}
-
-export function getExclusionKeys(key: string, excludeKeys: string[]): string[] {
-  if (!key || !excludeKeys) {
-    return [];
-  }
-
-  const exclusionKeys: string[] = [];
-  for (const exclusionKey of excludeKeys) {
-    if (exclusionKey.includes(key)) {
-      exclusionKeys.push(exclusionKey);
-    }
-  }
-
-  return exclusionKeys;
+  return stateSlices as E;
 }


### PR DESCRIPTION
Reverted 2 commits that touched this feature:
https://github.com/SAP/cloud-commerce-spartacus-storefront/commit/8e89ffedc9fb7efdb7e2ada59151dba91815757f
https://github.com/SAP/cloud-commerce-spartacus-storefront/commit/d15e792e12225670a1a4cda58b2b18c174bde28b

PRs that can be reopened and introduced to next beta:
https://github.com/SAP/cloud-commerce-spartacus-storefront/pull/3560
https://github.com/SAP/cloud-commerce-spartacus-storefront/pull/3662

For kyma I didn't noticed refresh_token returned from auth server and I am not sure if we need that exclusion mechanism.

Closes #3998 