### PR TITLE
Fix cms page logic execution

### DIFF
--- a/projects/storefrontlib/src/cms-structure/guards/cms-page.guard.ts
+++ b/projects/storefrontlib/src/cms-structure/guards/cms-page.guard.ts
@@ -11,14 +11,7 @@ import {
 } from '@spartacus/core';
 
 import { Observable, of } from 'rxjs';
-import {
-  filter,
-  first,
-  map,
-  switchMap,
-  tap,
-  withLatestFrom,
-} from 'rxjs/operators';
+import { filter, first, map, switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
 
 import { CmsGuardsService } from '../services/cms-guards.service';
 import { CmsI18nService } from '../services/cms-i18n.service';
@@ -64,6 +57,7 @@ export class CmsPageGuard implements CanActivate {
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> {
     return this.cmsService.getPageComponentTypes(pageContext).pipe(
+      take(1),
       switchMap(componentTypes =>
         this.cmsGuards
           .cmsPageCanActivate(componentTypes, route, state)

--- a/projects/storefrontlib/src/cms-structure/guards/cms-page.guard.ts
+++ b/projects/storefrontlib/src/cms-structure/guards/cms-page.guard.ts
@@ -11,7 +11,15 @@ import {
 } from '@spartacus/core';
 
 import { Observable, of } from 'rxjs';
-import { filter, first, map, switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
+import {
+  filter,
+  first,
+  map,
+  switchMap,
+  take,
+  tap,
+  withLatestFrom,
+} from 'rxjs/operators';
 
 import { CmsGuardsService } from '../services/cms-guards.service';
 import { CmsI18nService } from '../services/cms-i18n.service';


### PR DESCRIPTION
Fix bug causing that could cause double cms page logic execution in case of long-running guards.

Closes GH-4150