### PR TITLE
chore: Update release-it configs

### DIFF
--- a/projects/assets/.release-it.changelog.json
+++ b/projects/assets/.release-it.changelog.json
@@ -13,8 +13,7 @@
     "releaseNotes": "cd ../.. && npm run --silent release-notes:assets -- --from assets-${latestVersion} --to assets-${version}"
   },
   "npm": {
-    "publishPath": "./../../dist/assets",
-    "tag": "latest"
+    "publishPath": "./../../dist/assets"
   },
   "hooks": {
     "after:version:bump": "cd ../.. && yarn build:assets"

--- a/projects/assets/.release-it.json
+++ b/projects/assets/.release-it.json
@@ -7,8 +7,7 @@
     "tagAnnotation": "Bumping assets version to ${version}"
   },
   "npm": {
-    "publishPath": "./../../dist/assets",
-    "tag": "latest"
+    "publishPath": "./../../dist/assets"
   },
   "hooks": {
     "after:version:bump": "cd ../.. && yarn build:assets"

--- a/projects/core/.release-it.changelog.json
+++ b/projects/core/.release-it.changelog.json
@@ -7,11 +7,10 @@
     "tagAnnotation": "Bumping core version to ${version}"
   },
   "npm": {
-    "publishPath": "./../../dist/core",
-    "tag": "latest"
+    "publishPath": "./../../dist/core"
   },
   "hooks": {
-    "after:git:bump": "cd ../.. && ng build core"
+    "after:version:bump": "cd ../.. && ng build core"
   },
   "github": {
     "release": true,

--- a/projects/core/.release-it.json
+++ b/projects/core/.release-it.json
@@ -7,7 +7,9 @@
     "tagAnnotation": "Bumping core version to ${version}"
   },
   "npm": {
-    "publishPath": "./../../dist/core",
-    "tag": "latest"
-  }
+    "publishPath": "./../../dist/core"
+  },
+  "hooks": {
+    "after:version:bump": "cd ../.. && ng build core"
+  },
 }

--- a/projects/core/.release-it.json
+++ b/projects/core/.release-it.json
@@ -11,5 +11,5 @@
   },
   "hooks": {
     "after:version:bump": "cd ../.. && ng build core"
-  },
+  }
 }

--- a/projects/storefrontlib/.release-it.changelog.json
+++ b/projects/storefrontlib/.release-it.changelog.json
@@ -7,11 +7,10 @@
     "tagAnnotation": "Bumping storefront version to ${version}"
   },
   "npm": {
-    "publishPath": "./../../dist/storefrontlib",
-    "tag": "latest"
+    "publishPath": "./../../dist/storefrontlib"
   },
   "hooks": {
-    "after:git:bump": "cd ../.. && yarn build:core:lib"
+    "after:version:bump": "cd ../.. && yarn build:core:lib"
   },
   "github": {
     "release": true,

--- a/projects/storefrontlib/.release-it.json
+++ b/projects/storefrontlib/.release-it.json
@@ -7,10 +7,9 @@
     "tagAnnotation": "Bumping storefront version to ${version}"
   },
   "npm": {
-    "publishPath": "./../../dist/storefrontlib",
-    "tag": "latest"
+    "publishPath": "./../../dist/storefrontlib"
   },
   "hooks": {
-    "after:git:bump": "cd ../.. && yarn build:core:lib"
+    "after:version:bump": "cd ../.. && yarn build:core:lib"
   }
 }

--- a/projects/storefrontstyles/.release-it.changelog.json
+++ b/projects/storefrontstyles/.release-it.changelog.json
@@ -11,8 +11,5 @@
     "assets": ["../../docs.tar.gz", "../../docs.zip"],
     "releaseName": "@spartacus/styles@${version}",
     "releaseNotes": "cd ../.. && npm run --silent release-notes:styles -- --from styles-${latestVersion} --to styles-${version}"
-  },
-  "npm": {
-    "tag": "latest"
   }
 }

--- a/projects/storefrontstyles/.release-it.json
+++ b/projects/storefrontstyles/.release-it.json
@@ -5,8 +5,5 @@
     "tagName": "styles-${version}",
     "commitMessage": "Bumping styles version to ${version}",
     "tagAnnotation": "Bumping styles version to ${version}"
-  },
-  "npm": {
-    "tag": "latest"
   }
 }


### PR DESCRIPTION
For schematics release, `release-it` was updated.
Also fixed configs to match the new version and remove not needed parts after change in our git-flow.