### PR TITLE
feat: closed storefront

### DIFF
--- a/projects/core/src/auth/guards/auth-redirect.service.ts
+++ b/projects/core/src/auth/guards/auth-redirect.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
-
-import { RoutingService } from '../../routing/facade/routing.service';
 import { Router } from '@angular/router';
+import { RoutingService } from '../../routing/facade/routing.service';
 
 @Injectable({
   providedIn: 'root',

--- a/projects/core/src/auth/guards/auth.guard.ts
+++ b/projects/core/src/auth/guards/auth.guard.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
 import { RoutingService } from '../../routing/facade/routing.service';
 import { AuthService } from '../facade/auth.service';
 import { UserToken } from '../models/token-types.model';
@@ -23,8 +22,8 @@ export class AuthGuard implements CanActivate {
     return this.authService.getUserToken().pipe(
       map((token: UserToken) => {
         if (!token.access_token) {
-          this.routingService.go({ cxRoute: 'login' });
           this.authRedirectService.reportAuthGuard();
+          this.routingService.go({ cxRoute: 'login' });
         }
         return !!token.access_token;
       })

--- a/projects/core/src/routing/configurable-routes/config/routing-config.ts
+++ b/projects/core/src/routing/configurable-routes/config/routing-config.ts
@@ -2,6 +2,7 @@ import { RoutesConfig } from '../routes-config';
 
 export abstract class RoutingConfig {
   routing?: {
-    routes: RoutesConfig;
+    routes?: RoutesConfig;
+    protected?: boolean;
   };
 }

--- a/projects/core/src/routing/configurable-routes/config/routing-config.ts
+++ b/projects/core/src/routing/configurable-routes/config/routing-config.ts
@@ -2,7 +2,14 @@ import { RoutesConfig } from '../routes-config';
 
 export abstract class RoutingConfig {
   routing?: {
+    /**
+     * Configuration of semantic routes. Key is route's name. Value is the config specific to this route.
+     */
     routes?: RoutesConfig;
+
+    /**
+     * When true, it closes the storefront for unauthorized users, except from routes that have individual config flag `protected: false`
+     */
     protected?: boolean;
   };
 }

--- a/projects/core/src/routing/configurable-routes/routes-config.ts
+++ b/projects/core/src/routing/configurable-routes/routes-config.ts
@@ -6,6 +6,7 @@ export interface RouteConfig {
   paths?: string[];
   paramsMapping?: ParamsMapping;
   disabled?: boolean;
+  protected?: boolean;
 }
 
 export interface ParamsMapping {

--- a/projects/core/src/routing/configurable-routes/routes-config.ts
+++ b/projects/core/src/routing/configurable-routes/routes-config.ts
@@ -3,9 +3,25 @@ export interface RoutesConfig {
 }
 
 export interface RouteConfig {
+  /**
+   * List of path aliases to match with URL. Also used to build the semantic links.
+   */
   paths?: string[];
+
+  /**
+   * Maps names of route params with params used to build the semantic link.
+   */
   paramsMapping?: ParamsMapping;
+
+  /**
+   * Disables the url matcher for the route. But still allows for generation of semantic links.
+   */
   disabled?: boolean;
+
+  /**
+   * When false, the route is public for unauthorized users even when the global flag `routing.protected` is true.
+   * Other values (true, undefined) are ignored.
+   */
   protected?: boolean;
 }
 

--- a/projects/core/src/routing/index.ts
+++ b/projects/core/src/routing/index.ts
@@ -3,6 +3,7 @@ export * from './external-routes/index';
 export * from './facade/routing.service';
 export * from './models/cms-route';
 export * from './models/page-context.model';
+export * from './protected-routes/index';
 export * from './routing.module';
 export * from './services/index';
 export * from './store/actions/index';

--- a/projects/core/src/routing/protected-routes/index.ts
+++ b/projects/core/src/routing/protected-routes/index.ts
@@ -1,0 +1,2 @@
+export * from './protected-routes.guard';
+export * from './protected-routes.service';

--- a/projects/core/src/routing/protected-routes/protected-routes.guard.spec.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.guard.spec.ts
@@ -1,0 +1,96 @@
+import { Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { of } from 'rxjs';
+import { AuthGuard } from '../../auth/guards/auth.guard';
+import { ProtectedRoutesGuard } from './protected-routes.guard';
+import { ProtectedRoutesService } from './protected-routes.service';
+
+class MockAuthGuard {
+  canActivate = jasmine
+    .createSpy('AuthGuard.canActivate')
+    .and.returnValue(of('authGuard-result'));
+}
+
+class MockProtectedRoutesService {
+  isUrlProtected() {}
+}
+
+describe('ProtectedRoutesGuard', () => {
+  let guard: ProtectedRoutesGuard;
+  let service: ProtectedRoutesService;
+  let authGuard: AuthGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProtectedRoutesGuard,
+        {
+          provide: ProtectedRoutesService,
+          useClass: MockProtectedRoutesService,
+        },
+        {
+          provide: AuthGuard,
+          useClass: MockAuthGuard,
+        },
+      ],
+    });
+
+    guard = TestBed.get(ProtectedRoutesGuard as Type<ProtectedRoutesGuard>);
+    service = TestBed.get(ProtectedRoutesService as Type<
+      ProtectedRoutesService
+    >);
+    authGuard = TestBed.get(AuthGuard as Type<AuthGuard>);
+  });
+
+  describe('canActivate', () => {
+    describe('when anticipated url is NOT protected', () => {
+      beforeEach(() => {
+        console.log(guard, service, authGuard);
+        spyOn(service, 'isUrlProtected').and.returnValue(false);
+      });
+
+      it('should emit true', () => {
+        let result;
+        guard
+          .canActivate({ url: [] } as ActivatedRouteSnapshot)
+          .subscribe(res => (result = res));
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('when anticipated url is protected', () => {
+      beforeEach(() => {
+        console.log(guard, service, authGuard);
+        spyOn(service, 'isUrlProtected').and.returnValue(true);
+      });
+
+      it('should emit result of AuthGuard.canActivate', () => {
+        let result;
+        guard
+          .canActivate({ url: [] } as ActivatedRouteSnapshot)
+          .subscribe(res => (result = res))
+          .unsubscribe();
+        expect(result).toBe('authGuard-result');
+      });
+
+      it('should call service.isUrlProtected with segments of anticipated url', () => {
+        guard
+          .canActivate({
+            url: [{ path: 'hello' }, { path: 'world' }],
+          } as ActivatedRouteSnapshot)
+          .subscribe()
+          .unsubscribe();
+        expect(service.isUrlProtected).toHaveBeenCalledWith(['hello', 'world']);
+      });
+
+      it('should call service.isUrlProtected with array of empty string when the anticipated url is the root path', () => {
+        guard
+          .canActivate({ url: [] } as ActivatedRouteSnapshot)
+          .subscribe()
+          .unsubscribe();
+        expect(service.isUrlProtected).toHaveBeenCalledWith(['']);
+      });
+    });
+  });
+});

--- a/projects/core/src/routing/protected-routes/protected-routes.guard.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.guard.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { AuthGuard } from '../../auth/guards/auth.guard';
+import { ProtectedRoutesService } from './protected-routes.service';
+
+@Injectable({ providedIn: 'root' })
+export class ProtectedRoutesGuard implements CanActivate {
+  constructor(
+    protected service: ProtectedRoutesService,
+    protected authGuard: AuthGuard
+  ) {}
+
+  /**
+   * When the anticipated url is protected, it switches to the AuthGuard. Otherwise emits true.
+   */
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    let urlSegments: string[] = route.url.map(seg => seg.path);
+
+    // For the root path `/` ActivatedRoute contains an empty array of segments:
+    urlSegments = urlSegments.length ? urlSegments : [''];
+
+    if (this.service.isUrlProtected(urlSegments)) {
+      return this.authGuard.canActivate();
+    }
+    return of(true);
+  }
+}

--- a/projects/core/src/routing/protected-routes/protected-routes.service.spec.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.service.spec.ts
@@ -1,0 +1,161 @@
+import { Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { RoutingConfig } from '../configurable-routes/config/routing-config';
+import { ProtectedRoutesGuard } from './protected-routes.guard';
+import { ProtectedRoutesService } from './protected-routes.service';
+
+describe('ProtectedRoutesService', () => {
+  let service: ProtectedRoutesService;
+
+  function beforeEachWithConfig(routingConfig: RoutingConfig['routing']) {
+    const mockConfig: RoutingConfig = {
+      routing: routingConfig,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ProtectedRoutesGuard,
+        {
+          provide: RoutingConfig,
+          useValue: mockConfig,
+        },
+      ],
+    });
+
+    service = TestBed.get(ProtectedRoutesService as Type<
+      ProtectedRoutesService
+    >);
+  }
+
+  describe('isUrlProtected', () => {
+    describe(`when global protection is enabled and individual url's protection is undefined`, () => {
+      beforeEach(() => {
+        beforeEachWithConfig({
+          protected: true,
+          routes: {
+            login: { paths: ['login'] },
+          },
+        });
+      });
+
+      it('should return true', () => {
+        expect(service.isUrlProtected(['login'])).toBe(true);
+      });
+    });
+
+    describe('when global protection is disabled and individual url is marked as protected', () => {
+      beforeEach(() => {
+        beforeEachWithConfig({
+          protected: false,
+          routes: {
+            login: { paths: ['login'], protected: true },
+          },
+        });
+      });
+
+      it('should return false', () => {
+        expect(service.isUrlProtected(['login'])).toBe(false);
+      });
+    });
+
+    describe('when global protection is enabled and individual url is marked as protected', () => {
+      beforeEach(() => {
+        beforeEachWithConfig({
+          protected: true,
+          routes: {
+            login: { paths: ['login'], protected: true },
+          },
+        });
+      });
+
+      it('should return true', () => {
+        expect(service.isUrlProtected(['login'])).toBe(true);
+      });
+    });
+
+    describe('when global protection is enabled and individual url is marked as NOT protected', () => {
+      beforeEach(() => {
+        beforeEachWithConfig({
+          protected: true,
+          routes: {
+            login: { paths: ['login'], protected: false },
+          },
+        });
+      });
+
+      it('should return false', () => {
+        expect(service.isUrlProtected(['login'])).toBe(false);
+      });
+    });
+
+    describe('when global protection is enabled and two urls are marked as NOT protected', () => {
+      beforeEach(() => {
+        beforeEachWithConfig({
+          protected: true,
+          routes: {
+            login: { paths: ['login'], protected: false },
+            cart: { paths: ['cart'] },
+            register: { paths: ['register'], protected: false },
+          },
+        });
+      });
+
+      it('should return false for each of them', () => {
+        expect(service.isUrlProtected(['login'])).toBe(false);
+        expect(service.isUrlProtected(['cart'])).toBe(true);
+        expect(service.isUrlProtected(['register'])).toBe(false);
+      });
+    });
+
+    describe('when global protection is enabled and url marked as NOT protected contains route params', () => {
+      beforeEach(() => {
+        beforeEachWithConfig({
+          protected: true,
+          routes: {
+            product: {
+              paths: ['product/:productName/:productCode'],
+              protected: false,
+            },
+          },
+        });
+      });
+
+      it('should return false for each of aliases', () => {
+        expect(service.isUrlProtected(['product', '1234'])).toBe(true);
+        expect(service.isUrlProtected(['product', 'camera', '1234'])).toBe(
+          false
+        );
+        expect(
+          service.isUrlProtected(['product', 'camera', '1234', 'test-test'])
+        ).toBe(true);
+      });
+    });
+
+    describe('when global protection is enabled and url marked as NOT protected has configured route aliases', () => {
+      beforeEach(() => {
+        beforeEachWithConfig({
+          protected: true,
+          routes: {
+            product: {
+              paths: [
+                'product/:productCode',
+                'product/:productName/:productCode',
+              ],
+              protected: false,
+            },
+          },
+        });
+      });
+
+      it('should return false for each of aliases', () => {
+        expect(service.isUrlProtected(['product', '1234'])).toBe(false);
+        expect(service.isUrlProtected(['product', 'camera', '1234'])).toBe(
+          false
+        );
+        expect(
+          service.isUrlProtected(['product', 'camera', '1234', 'test-test'])
+        ).toBe(true);
+      });
+    });
+  });
+});

--- a/projects/core/src/routing/protected-routes/protected-routes.service.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@angular/core';
+import { RoutingConfig } from '../configurable-routes/config/routing-config';
+
+@Injectable({ providedIn: 'root' })
+export class ProtectedRoutesService {
+  private nonProtectedPathsSegments: string[][] = []; // arrays of paths' segments list
+
+  protected get routingConfig(): RoutingConfig['routing'] {
+    return this.config && this.config.routing;
+  }
+
+  protected get shouldProtect(): boolean {
+    return this.routingConfig.protected;
+  }
+
+  constructor(protected config: RoutingConfig) {
+    if (this.shouldProtect) {
+      // pre-process config for performance:
+      this.nonProtectedPathsSegments = this.getNonProtectedPathsSegments().map(
+        path => this.getSegments(path)
+      );
+    }
+  }
+
+  /**
+   * Tells if the url is protected
+   */
+  isUrlProtected(urlSegments: string[]): boolean {
+    return (
+      this.shouldProtect &&
+      !this.matchAnyPath(urlSegments, this.nonProtectedPathsSegments)
+    );
+  }
+
+  /**
+   * Tells whether the url matches at least one of the paths
+   */
+  protected matchAnyPath(
+    urlSegments: string[],
+    pathsSegments: string[][]
+  ): boolean {
+    return pathsSegments.some(pathSegments =>
+      this.matchPath(urlSegments, pathSegments)
+    );
+  }
+
+  /**
+   * Tells whether the url matches the path
+   */
+  protected matchPath(urlSegments: string[], pathSegments: string[]): boolean {
+    if (urlSegments.length !== pathSegments.length) {
+      return false;
+    }
+
+    for (let i = 0; i < pathSegments.length; i++) {
+      const pathSeg = pathSegments[i];
+      const urlSeg = urlSegments[i];
+
+      // compare only static segments:
+      if (!pathSeg.startsWith(':') && pathSeg !== urlSeg) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns a list of paths that are not protected
+   */
+  protected getNonProtectedPathsSegments(): string[] {
+    const result: string[] = [];
+    Object.keys(this.routingConfig.routes).forEach(key => {
+      const routeConfig = this.routingConfig.routes[key];
+      if (
+        routeConfig.protected === false && // ignore undefined
+        routeConfig.paths &&
+        routeConfig.paths.length
+      ) {
+        result.push(...routeConfig.paths);
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Splits the url by slashes
+   */
+  protected getSegments(url: string): string[] {
+    return (url || '').split('/');
+  }
+}

--- a/projects/core/src/routing/protected-routes/protected-routes.service.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.service.ts
@@ -3,7 +3,7 @@ import { RoutingConfig } from '../configurable-routes/config/routing-config';
 
 @Injectable({ providedIn: 'root' })
 export class ProtectedRoutesService {
-  private nonProtectedPathsSegments: string[][] = []; // arrays of paths' segments list
+  private nonProtectedPaths: string[][] = []; // arrays of paths' segments list
 
   protected get routingConfig(): RoutingConfig['routing'] {
     return this.config && this.config.routing;
@@ -16,8 +16,8 @@ export class ProtectedRoutesService {
   constructor(protected config: RoutingConfig) {
     if (this.shouldProtect) {
       // pre-process config for performance:
-      this.nonProtectedPathsSegments = this.getNonProtectedPathsSegments().map(
-        path => this.getSegments(path)
+      this.nonProtectedPaths = this.getNonProtectedPaths().map(path =>
+        this.getSegments(path)
       );
     }
   }
@@ -28,7 +28,7 @@ export class ProtectedRoutesService {
   isUrlProtected(urlSegments: string[]): boolean {
     return (
       this.shouldProtect &&
-      !this.matchAnyPath(urlSegments, this.nonProtectedPathsSegments)
+      !this.matchAnyPath(urlSegments, this.nonProtectedPaths)
     );
   }
 
@@ -67,7 +67,7 @@ export class ProtectedRoutesService {
   /**
    * Returns a list of paths that are not protected
    */
-  protected getNonProtectedPathsSegments(): string[] {
+  protected getNonProtectedPaths(): string[] {
     const result: string[] = [];
     Object.keys(this.routingConfig.routes).forEach(key => {
       const routeConfig = this.routingConfig.routes[key];

--- a/projects/core/src/routing/protected-routes/protected-routes.service.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.service.ts
@@ -19,6 +19,7 @@ export class ProtectedRoutesService {
       this.nonProtectedPaths = this.getNonProtectedPaths().map(path =>
         this.getSegments(path)
       );
+      debugger;
     }
   }
 
@@ -68,18 +69,15 @@ export class ProtectedRoutesService {
    * Returns a list of paths that are not protected
    */
   protected getNonProtectedPaths(): string[] {
-    const result: string[] = [];
-    Object.keys(this.routingConfig.routes).forEach(key => {
-      const routeConfig = this.routingConfig.routes[key];
-      if (
-        routeConfig.protected === false && // ignore undefined
+    return Object.values(this.routingConfig.routes).reduce(
+      (acc, routeConfig) =>
+        routeConfig.protected === false && // must be explicitly false, ignore undefined
         routeConfig.paths &&
         routeConfig.paths.length
-      ) {
-        result.push(...routeConfig.paths);
-      }
-    });
-    return result;
+          ? acc.concat(routeConfig.paths)
+          : acc,
+      []
+    );
   }
 
   /**

--- a/projects/core/src/routing/protected-routes/protected-routes.service.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.service.ts
@@ -19,7 +19,6 @@ export class ProtectedRoutesService {
       this.nonProtectedPaths = this.getNonProtectedPaths().map(path =>
         this.getSegments(path)
       );
-      debugger;
     }
   }
 

--- a/projects/storefrontlib/src/cms-structure/guards/cms-page.guard.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/guards/cms-page.guard.spec.ts
@@ -6,6 +6,7 @@ import {
   CmsActivatedRouteSnapshot,
   CmsService,
   PageType,
+  ProtectedRoutesGuard,
   RoutingService,
   SemanticPathService,
 } from '@spartacus/core';
@@ -46,6 +47,10 @@ class MockCmsGuardsService {
     .and.returnValue(of(true));
 }
 
+class MockProtectedRoutesGuard {
+  canActivate = () => of(true);
+}
+
 class MockSemanticPathService {
   get() {}
 }
@@ -64,6 +69,7 @@ describe('CmsPageGuard', () => {
         { provide: CmsI18nService, useClass: MockCmsI18nService },
         { provide: CmsGuardsService, useClass: MockCmsGuardsService },
         { provide: SemanticPathService, useClass: MockSemanticPathService },
+        { provide: ProtectedRoutesGuard, useClass: MockProtectedRoutesGuard },
       ],
       imports: [RouterTestingModule],
     });
@@ -75,6 +81,23 @@ describe('CmsPageGuard', () => {
   });
 
   describe('canActivate', () => {
+    it('should emit result of ProtectedRoutesGuard when it emits false', inject(
+      [ProtectedRoutesGuard, CmsPageGuard],
+      (
+        protectedRoutesGuard: ProtectedRoutesGuard,
+        cmsPageGuard: CmsPageGuard
+      ) => {
+        spyOn(protectedRoutesGuard, 'canActivate').and.returnValue(of(false));
+        let result: boolean | UrlTree;
+        cmsPageGuard
+          .canActivate(mockRouteSnapshot, undefined)
+          .subscribe(value => (result = value))
+          .unsubscribe();
+
+        expect(result).toBe(false);
+      }
+    ));
+
     it('should return true when CmsService getPage is truthy for the page context', inject(
       [CmsService, CmsPageGuard],
       (cmsService: CmsService, cmsPageGuard: CmsPageGuard) => {

--- a/projects/storefrontlib/src/cms-structure/routing/default-routing-config.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/default-routing-config.ts
@@ -6,11 +6,12 @@ export const defaultStorefrontRoutesConfig: RoutesConfig = {
   cart: { paths: ['cart'] },
 
   // semantic links for login related pages
-  login: { paths: ['login'] },
+  login: { paths: ['login'], protected: false },
+  register: { paths: ['login/register'], protected: false },
+  forgotPassword: { paths: ['login/forgot-password'], protected: false },
+  resetPassword: { paths: ['login/pw/change'], protected: false },
   logout: { paths: ['logout'] },
-  register: { paths: ['login/register'] },
   checkoutLogin: { paths: ['checkout-login'] },
-  forgotPassword: { paths: ['login/forgot-password'] },
 
   checkout: { paths: ['checkout'] },
   checkoutShippingAddress: { paths: ['checkout/shipping-address'] },


### PR DESCRIPTION
A lot of B2B storefronts need a closed store, which you cannot enter without logging in. There will be typically at least one page (login) public, or a few (such as register, help, support, etc.).

In order to achieve this now we configure in our libraries the Login related pages (login, register, forget password) as a public routes, In order to enable/disable the closed storefront we introduce one configuration to close the storefront.

By the way:
- fixed a bug: After login you should be redirected back to the anticipated protected page (not the last openend page). 
- marked as `protected` a few dependencies in the constructor of `CmsPageGuard` - only those exposed in our Public API

close GH-4594