### PR TITLE
chore: Fix import in release notes generation script

### DIFF
--- a/scripts/versions.ts
+++ b/scripts/versions.ts
@@ -1,6 +1,6 @@
-import pkgVersions from 'npm-package-versions';
 import * as semverExtra from 'semver-extra';
 import * as semver from 'semver';
+import pkgVersions = require('npm-package-versions');
 
 function pkgVersionsPromise(packageName: string) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Release note script wasn't working correctly. `npm-package-versions` is a common js module and standard import didn't worked correctly with default export.