### PR TITLE
fix: escape special characters for url params in url generation

### DIFF
--- a/projects/core/src/occ/services/occ-endpoints.service.spec.ts
+++ b/projects/core/src/occ/services/occ-endpoints.service.spec.ts
@@ -103,5 +103,17 @@ describe('OccEndpointsService', () => {
 
       expect(url).toEqual(baseEndpoint + '/configured-endpoint1/test-value');
     });
+
+    it('should escape special characters passed in url params', () => {
+      const url = service.getUrl(
+        'product',
+        { test: 'ąćę$%' },
+        { fields: null }
+      );
+
+      expect(url).toEqual(
+        baseEndpoint + '/configured-endpoint1/%C4%85%C4%87%C4%99%24%25'
+      );
+    });
   });
 });

--- a/projects/core/src/occ/services/occ-endpoints.service.ts
+++ b/projects/core/src/occ/services/occ-endpoints.service.ts
@@ -85,6 +85,9 @@ export class OccEndpointsService {
     }
 
     if (urlParams) {
+      Object.keys(urlParams).forEach(key => {
+        urlParams[key] = encodeURIComponent(urlParams[key]);
+      });
       endpoint = DynamicTemplate.resolve(endpoint, urlParams);
     }
 


### PR DESCRIPTION
Closes: #4814 