### PR TITLE
chore: Fix tsconfig to match Assertion types

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/tsconfig.json
+++ b/projects/storefrontapp-e2e-cypress/cypress/tsconfig.json
@@ -7,5 +7,6 @@
     "target": "es5",
     "lib": ["esnext", "dom"]
   },
-  "include": ["**/*.*"]
+  "include": ["**/*.*"],
+  "exclude": ["./dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
       "@spartacus/assets": ["projects/assets/src/public_api"]
     }
   },
-  "exclude": ["./dist"]
+  "exclude": ["./dist", "./projects/storefrontapp-e2e-cypress"]
 }


### PR DESCRIPTION
Assertion type was set to use Chai everywhere (even in karma/jasmine) tests.

Fixed `tsconfig` files to correctly match this type in different spec files.