### PR TITLE
fix: Add ngx-infinite-scroll to list of peer dependencies (GH-4857)

### DIFF
--- a/projects/storefrontlib/package.json
+++ b/projects/storefrontlib/package.json
@@ -31,6 +31,7 @@
     "@spartacus/styles": "^1.0.0",
     "bootstrap": "^4.2.1",
     "rxjs": "^6.4.0",
-    "zone.js": "^0.9.1"
+    "zone.js": "^0.9.1",
+    "ngx-infinite-scroll": "^8.0.0"
   }
 }


### PR DESCRIPTION
Closes GH-4857