### PR TITLE
Fix: Apply coupon to anonymous cart returns Cart not found (GH-5189)

### DIFF
--- a/projects/core/src/cart/facade/cart-voucher.service.ts
+++ b/projects/core/src/cart/facade/cart-voucher.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
-import { Observable, combineLatest, of } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { take, map } from 'rxjs/operators';
 import { AuthService } from '../../auth/index';
 import * as fromProcessStore from '../../process/store/process-state';
@@ -12,6 +12,7 @@ import {
 import { CartActions } from '../store/actions/index';
 import { ADD_VOUCHER_PROCESS_ID, StateWithCart } from '../store/cart-state';
 import { CartSelectors } from '../store/selectors/index';
+import { OCC_USER_ID_ANONYMOUS, Cart } from '@spartacus/core';
 
 @Injectable()
 export class CartVoucherService {
@@ -69,14 +70,25 @@ export class CartVoucherService {
   }
 
   private combineUserAndCartId(cartId: string): Observable<[string, string]> {
-    return combineLatest([
-      this.authService.getOccUserId(),
-      cartId
-        ? of(cartId)
-        : this.store.pipe(
-            select(CartSelectors.getCartContent),
-            map(cart => cart.code)
-          ),
-    ]).pipe(take(1));
+    if (cartId) {
+      return this.authService.getOccUserId().pipe(
+        take(1),
+        map(userId => [userId, cartId])
+      );
+    } else {
+      return combineLatest([
+        this.authService.getOccUserId(),
+        this.store.pipe(
+          select(CartSelectors.getCartContent),
+          map(cart => cart)
+        ),
+      ]).pipe(
+        take(1),
+        map(([userId, cart]: [string, Cart]) => [
+          userId,
+          userId === OCC_USER_ID_ANONYMOUS ? cart.guid : cart.code,
+        ])
+      );
+    }
   }
 }

--- a/projects/core/src/cart/facade/cart-voucher.service.ts
+++ b/projects/core/src/cart/facade/cart-voucher.service.ts
@@ -12,7 +12,8 @@ import {
 import { CartActions } from '../store/actions/index';
 import { ADD_VOUCHER_PROCESS_ID, StateWithCart } from '../store/cart-state';
 import { CartSelectors } from '../store/selectors/index';
-import { OCC_USER_ID_ANONYMOUS, Cart } from '@spartacus/core';
+import { Cart } from '../../model/cart.model';
+import { OCC_USER_ID_ANONYMOUS } from '../../occ/utils/occ-constants';
 
 @Injectable()
 export class CartVoucherService {

--- a/projects/storefrontlib/src/cms-components/cart/cart-coupon/cart-coupon.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/cart/cart-coupon/cart-coupon.component.spec.ts
@@ -9,6 +9,7 @@ import {
   Voucher,
   Cart,
   CartVoucherService,
+  AuthService,
 } from '@spartacus/core';
 import { of } from 'rxjs';
 import { CartCouponComponent } from './cart-coupon.component';
@@ -46,6 +47,8 @@ describe('CartCouponComponent', () => {
     'getLoaded',
   ]);
 
+  const mockAuthService = jasmine.createSpyObj('AuthService', ['getOccUserId']);
+
   const mockCartVoucherService = jasmine.createSpyObj('CartVoucherService', [
     'addVoucher',
     'getAddVoucherResultSuccess',
@@ -63,6 +66,7 @@ describe('CartCouponComponent', () => {
       ],
       providers: [
         { provide: CartService, useValue: mockCartService },
+        { provide: AuthService, useValue: mockAuthService },
         { provide: CartVoucherService, useValue: mockCartVoucherService },
       ],
     }).compileComponents();
@@ -75,6 +79,7 @@ describe('CartCouponComponent', () => {
 
     mockCartService.getActive.and.returnValue(of<Cart>({ code: '123' }));
     mockCartService.getLoaded.and.returnValue(of(true));
+    mockAuthService.getOccUserId.and.returnValue(of('testUserId'));
     mockCartVoucherService.getAddVoucherResultSuccess.and.returnValue(of());
     mockCartVoucherService.getAddVoucherResultLoading.and.returnValue(of());
     mockCartVoucherService.addVoucher.and.stub();


### PR DESCRIPTION
Improve the logic to get cartId which should be cart.guid when anonymous applying coupon in cart page

Breaking Changes:
Unit tests of cart-voucher.service and cart-coupon.component

Closed #5189 