### PR TITLE
chore: Enable @internal docs for methods/classes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "strictPropertyInitialization": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "stripInternal": true,
     "paths": {
       "@spartacus/core": ["projects/core/public_api"],
       "@spartacus/storefront": ["projects/storefrontlib/src/public_api"],


### PR DESCRIPTION
It gives much more control in terms of shaping our public API. Now with `\** @internal *\` comment, you can mark method/class to be visible as public only in the library itself. The method is not available in public API.

🚨  **Warning**: don't use on constructor!

To test:
- mark public method that is used only in the same lib eg. `AuthService.getOccUserId`
- check if you can use it in other files in the same lib
- check if it is hidden in public API (try to import in `app.module.ts`)

Closes #5209 