### PR TITLE
feat (styles): introduce theme driven page templates

### DIFF
--- a/projects/storefrontstyles/_index.scss
+++ b/projects/storefrontstyles/_index.scss
@@ -1,3 +1,3 @@
 @import 'scss/app';
 @import 'scss/root';
-@import 'scss/layout/index';
+@import 'scss/page-template';

--- a/projects/storefrontstyles/scss/_page-template.scss
+++ b/projects/storefrontstyles/scss/_page-template.scss
@@ -1,0 +1,24 @@
+@import './cxbase/mixins';
+
+@import './layout/index';
+
+// The $page-template-blacklist can be used to prevent template CSS
+// being generated.
+$page-template-blacklist: () !default;
+
+// whitelisted page template selectors are processed
+// unless (some) they are blacklisted using `$page-template-blacklist`
+$page-template-whitelist: LandingPage2Template, ContentPage1Template,
+  CategoryPageTemplate, ProductListPageTemplate, SearchResultsListPageTemplate,
+  ProductDetailsPageTemplate, CartPageTemplate, LoginPageTemplate,
+  MultiStepCheckoutSummaryPageTemplate, ErrorPageTemplate,
+  StoreFinderPageTemplate, CheckoutLoginPageTemplate, AccountPageTemplate !default;
+
+@each $selector in $page-template-whitelist {
+  .#{$selector} {
+    @if (index($page-template-blacklist, $selector) == null) {
+      @extend %#{$selector} !optional;
+      @extend %#{$selector}-#{$theme} !optional;
+    }
+  }
+}

--- a/projects/storefrontstyles/scss/_sparta-theme.scss
+++ b/projects/storefrontstyles/scss/_sparta-theme.scss
@@ -38,9 +38,6 @@ $selectors: header, cx-storefront, cx-site-context-selector, cx-breadcrumb,
   cx-anonymous-consent-dialog, cx-anonymous-consent-open-dialog,
   cx-consent-management-form, cx-consent-management, cx-consent-management-form !default;
 
-// future theme's, can be introduced during minors
-$theme: '' !default;
-
 @each $selector in $selectors {
   #{$selector} {
     // skip selectors if they're added to the $skipComponentStyles list

--- a/projects/storefrontstyles/scss/cxbase/_mixins.scss
+++ b/projects/storefrontstyles/scss/cxbase/_mixins.scss
@@ -1,8 +1,8 @@
 /** 
  * the mixins depend on variables, mainly because of some
- * lower level bootstrap variables. Hence we variables here,
+ * lower level bootstrap variables. Hence we import the variables here,
  * to make the mixins resuable. In order to have the right variables
- * we load variables throug the theme import. 
+ * we load variables through the theme import. 
  */
 @import '../theme';
 

--- a/projects/storefrontstyles/scss/cxbase/_mixins.scss
+++ b/projects/storefrontstyles/scss/cxbase/_mixins.scss
@@ -1,4 +1,13 @@
+/** 
+ * the mixins depend on variables, mainly because of some
+ * lower level bootstrap variables. Hence we variables here,
+ * to make the mixins resuable. In order to have the right variables
+ * we load variables throug the theme import. 
+ */
+@import '../theme';
+
 @import '~bootstrap/scss/_mixins';
+
 @import './mixins/reset';
 @import './mixins/weight';
 @import './mixins/type';

--- a/projects/storefrontstyles/scss/cxbase/_variables.scss
+++ b/projects/storefrontstyles/scss/cxbase/_variables.scss
@@ -16,7 +16,7 @@
 @import 'functions';
 @import '~bootstrap/scss/variables';
 
-// future theme's, can be introduced during minors
+// future themes can be introduced during minors
 $theme: '' !default;
 
 $background: $white !default;

--- a/projects/storefrontstyles/scss/cxbase/_variables.scss
+++ b/projects/storefrontstyles/scss/cxbase/_variables.scss
@@ -14,7 +14,6 @@
 */
 
 @import 'functions';
-@import 'mixins';
 @import '~bootstrap/scss/variables';
 
 // future theme's, can be introduced during minors

--- a/projects/storefrontstyles/scss/cxbase/_variables.scss
+++ b/projects/storefrontstyles/scss/cxbase/_variables.scss
@@ -12,9 +12,13 @@
   so a variable was created to make this available for other themes.
 
 */
+
 @import 'functions';
 @import 'mixins';
 @import '~bootstrap/scss/variables';
+
+// future theme's, can be introduced during minors
+$theme: '' !default;
 
 $background: $white !default;
 $inverse: $white !default;

--- a/projects/storefrontstyles/scss/layout/_index.scss
+++ b/projects/storefrontstyles/scss/layout/_index.scss
@@ -12,71 +12,7 @@
 @import './page-templates/multistep-checkout-page';
 @import './page-templates/store-finder-page';
 
-cx-page-layout {
-  @extend %cx-page-layout !optional;
-}
-
-cx-page-slot {
-  @extend %cx-page-slot !optional;
-}
-
-cx-paragraph {
-  @extend %cx-paragraph !optional;
-}
-
-cx-category-navigation {
-  @extend %cx-category-navigation !optional;
-}
-
-.LandingPage2Template {
-  @extend %LandingPage2Template !optional;
-}
-
-.ContentPage1Template {
-  @extend %ContentPage1Template !optional;
-}
-
-.CategoryPageTemplate {
-  @extend %CategoryPageTemplate !optional;
-}
-
-.ProductListPageTemplate {
-  @extend %ProductListPageTemplate !optional;
-}
-
-.SearchResultsListPageTemplate {
-  @extend %SearchResultsListPageTemplate !optional;
-}
-
-.ProductDetailsPageTemplate {
-  @extend %ProductDetailsPageTemplate !optional;
-}
-
-.CartPageTemplate {
-  @extend %CartPageTemplate !optional;
-}
-
-.LoginPageTemplate {
+%CheckoutLoginPageTemplate {
   @extend %LoginPageTemplate !optional;
-}
-
-.CheckoutLoginPageTemplate {
-  @extend %LoginPageTemplate !optional;
-}
-
-.AccountPageTemplate {
-  --cx-max-width: 100%;
-  @extend %LoginPageTemplate !optional;
-}
-
-.MultiStepCheckoutSummaryPageTemplate {
-  @extend %MultiStepCheckoutSummaryPageTemplate !optional;
-}
-
-.ErrorPageTemplate {
-  @extend %ErrorPageTemplate !optional;
-}
-
-.StoreFinderPageTemplate {
-  @extend %StoreFinderPageTemplate !optional;
+  @extend %LoginPageTemplate-#{$theme} !optional;
 }

--- a/projects/storefrontstyles/scss/layout/page-templates/_common-template.scss
+++ b/projects/storefrontstyles/scss/layout/page-templates/_common-template.scss
@@ -1,4 +1,4 @@
-%cx-page-layout {
+cx-page-layout {
   display: block;
   width: 100%;
 
@@ -24,14 +24,17 @@
     color: var(--cx-color, var(--cx-color-inverse));
   }
 }
-%cx-page-slot {
+
+cx-page-slot {
   // smartedit requires every slot to be rendered in block mode
   // most likely it cannot make an overlay without some minimal sizingn
   display: block;
 }
-%cx-paragraph {
+
+cx-paragraph {
   display: block;
 }
-%cx-category-navigation {
+
+cx-category-navigation {
   display: block;
 }

--- a/projects/storefrontstyles/scss/layout/page-templates/_order-detail-page.scss
+++ b/projects/storefrontstyles/scss/layout/page-templates/_order-detail-page.scss
@@ -1,4 +1,8 @@
-.AccountPageTemplate {
+%AccountPageTemplate {
+  --cx-max-width: 100%;
+  @extend %LoginPageTemplate !optional;
+  @extend %LoginPageTemplate-#{$theme} !optional;
+
   cx-order-details-headline {
     order: 1;
   }

--- a/projects/storefrontstyles/scss/layout/page-templates/_product-detail.scss
+++ b/projects/storefrontstyles/scss/layout/page-templates/_product-detail.scss
@@ -3,7 +3,7 @@
 
   cx-page-slot {
     &.Summary {
-      @extend .container;
+      @extend .container !optional;
       margin-bottom: 40px;
 
       @include media-breakpoint-up(lg) {
@@ -45,6 +45,6 @@
   }
 
   .tab-delivery {
-    @extend .container;
+    @extend .container !optional;
   }
 }

--- a/projects/storefrontstyles/scss/theme/sparta/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/sparta/_variables.scss
@@ -10,7 +10,6 @@
     1) Add new variables
 */
 @import '../../cxbase/functions';
-@import '../../cxbase/mixins';
 
 //fonts (see _fonts.scss to import)
 $font-family-sans-serif: 'Open Sans', -apple-system, BlinkMacSystemFont,


### PR DESCRIPTION
Similar to the theming we use for components (i.e. calydon), we can now use a theme for a page layouts. The page layout can have addition placeholder selectors, so that whenever the theme is used, additional styles rules are added to the final CSS. 

Additional, we introduced a white and blacklist of page templates so that customers can more easily opt-out of certain page template styles. The variables are `$page-template-blacklist` and `$page-template-whitelist`. 

Moreover, the page templates can now be imported separately, using `@import '@spartacus/styles/scss/page-template';`

closes #5159