### PR TITLE
Add components dynamically to outlets

### DIFF
--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
@@ -1,4 +1,5 @@
 import {
+  ComponentFactory,
   Directive,
   Input,
   OnInit,
@@ -27,21 +28,22 @@ export class OutletDirective implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const nodes = [];
-    nodes.push(...this.renderTemplate(OutletPosition.BEFORE));
-    nodes.push(...this.renderTemplate(OutletPosition.REPLACE, true));
-    nodes.push(...this.renderTemplate(OutletPosition.AFTER));
+    this.renderTemplate(OutletPosition.BEFORE);
+    this.renderTemplate(OutletPosition.REPLACE, true);
+    this.renderTemplate(OutletPosition.AFTER);
   }
 
-  private renderTemplate(position: OutletPosition, replace = false): any[] {
-    const nodes = [];
+  private renderTemplate(position: OutletPosition, replace = false): void {
     const template = this.outletService.get(this.cxOutlet, position);
-    if (template || replace) {
-      const ref = this.vcr.createEmbeddedView(template || this.templateRef, {
-        $implicit: this._context,
-      });
-      nodes.push(...ref.rootNodes);
+    if (template && template instanceof ComponentFactory) {
+      this.vcr.createComponent(template);
+    } else if ((template && template instanceof TemplateRef) || replace) {
+      this.vcr.createEmbeddedView(
+        <TemplateRef<any>>template || this.templateRef,
+        {
+          $implicit: this._context,
+        }
+      );
     }
-    return nodes;
   }
 }

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.service.spec.ts
@@ -1,0 +1,199 @@
+import {
+  Component,
+  ComponentFactory,
+  ComponentFactoryResolver,
+  NgModule,
+  TemplateRef,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { OutletRefDirective } from './outlet-ref/outlet-ref.directive';
+import { OutletPosition } from './outlet.model';
+import { OutletService } from './outlet.service';
+
+const OUTLET_NAME_1 = 'OUTLET.1';
+const OUTLET_NAME_2 = 'OUTLET.2';
+const OUTLET_NAME_3 = 'OUTLET.3';
+
+@Component({
+  template: `
+    <ng-template cxOutletRef="${OUTLET_NAME_1}"> </ng-template>
+    <ng-template cxOutletRef="${OUTLET_NAME_2}" cxOutletPos="before">
+    </ng-template>
+    <ng-template cxOutletRef="${OUTLET_NAME_3}" cxOutletPos="after">
+    </ng-template>
+  `,
+})
+class TestContainerComponent {}
+
+@Component({
+  template: `
+    any
+  `,
+})
+class AnyComponent {}
+@NgModule({
+  declarations: [AnyComponent],
+  entryComponents: [AnyComponent],
+})
+class AnyModule {}
+
+describe('OutletService', () => {
+  let outletService: OutletService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AnyModule],
+      declarations: [TestContainerComponent, OutletRefDirective],
+      providers: [OutletService],
+    }).compileComponents();
+
+    outletService = TestBed.get(OutletService);
+  });
+
+  it('should be created', () => {
+    expect(outletService).toBeTruthy();
+  });
+
+  describe('Add TemplateRef', () => {
+    let fixture: ComponentFixture<TestContainerComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestContainerComponent);
+      fixture.detectChanges();
+    });
+
+    describe('BEFORE position', () => {
+      it('should have TemplateRef', () => {
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.BEFORE) instanceof
+            TemplateRef
+        ).toBeTruthy();
+      });
+
+      it('should have TemplateRef', () => {
+        expect(outletService.get(OUTLET_NAME_2)).toBeFalsy();
+      });
+
+      it('should have TemplateRef', () => {
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.AFTER)
+        ).toBeFalsy();
+      });
+    });
+
+    describe('REPLACE position', () => {
+      it('should have TemplateRef', () => {
+        expect(
+          outletService.get(OUTLET_NAME_1) instanceof TemplateRef
+        ).toBeTruthy();
+      });
+      it('should not have TemplateRef for BEFORE', () => {
+        expect(
+          outletService.get(OUTLET_NAME_1, OutletPosition.BEFORE)
+        ).toBeFalsy();
+      });
+      it('should not have TemplateRef for AFTER', () => {
+        expect(
+          outletService.get(OUTLET_NAME_1, OutletPosition.AFTER)
+        ).toBeFalsy();
+      });
+    });
+
+    describe('AFTER position', () => {
+      it('should have TemplateRef', () => {
+        expect(
+          outletService.get(OUTLET_NAME_3, OutletPosition.AFTER) instanceof
+            TemplateRef
+        ).toBeTruthy();
+      });
+
+      it('should have TemplateRef', () => {
+        expect(outletService.get(OUTLET_NAME_3)).toBeFalsy();
+      });
+
+      it('should have TemplateRef', () => {
+        expect(
+          outletService.get(OUTLET_NAME_3, OutletPosition.BEFORE)
+        ).toBeFalsy();
+      });
+    });
+  });
+
+  describe('Add Component Factory', () => {
+    let componentFactoryResolver: ComponentFactoryResolver;
+    let factory: ComponentFactory<any>;
+
+    beforeEach(() => {
+      componentFactoryResolver = TestBed.get(ComponentFactoryResolver);
+      factory = componentFactoryResolver.resolveComponentFactory(AnyComponent);
+    });
+
+    describe('REPLACE position', () => {
+      it('should return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory);
+        expect(
+          outletService.get(OUTLET_NAME_2) instanceof ComponentFactory
+        ).toBeTruthy();
+      });
+
+      it('should not return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory, OutletPosition.BEFORE);
+        expect(outletService.get(OUTLET_NAME_2)).toBeFalsy();
+      });
+      it('should not return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory, OutletPosition.AFTER);
+        expect(outletService.get(OUTLET_NAME_2)).toBeFalsy();
+      });
+    });
+
+    describe('BEFORE position', () => {
+      it('should return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory, OutletPosition.BEFORE);
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.BEFORE) instanceof
+            ComponentFactory
+        ).toBeTruthy();
+      });
+
+      it('should not return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory);
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.BEFORE) instanceof
+            ComponentFactory
+        ).toBeFalsy();
+      });
+
+      it('should not return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory, OutletPosition.AFTER);
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.BEFORE) instanceof
+            ComponentFactory
+        ).toBeFalsy();
+      });
+    });
+
+    describe('AFTER position', () => {
+      it('should return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory, OutletPosition.AFTER);
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.AFTER) instanceof
+            ComponentFactory
+        ).toBeTruthy();
+      });
+
+      it('should not return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory);
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.AFTER)
+        ).toBeFalsy();
+      });
+
+      it('should not return a factory', () => {
+        outletService.add(OUTLET_NAME_2, factory, OutletPosition.BEFORE);
+        expect(
+          outletService.get(OUTLET_NAME_2, OutletPosition.AFTER)
+        ).toBeFalsy();
+      });
+    });
+  });
+});

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.service.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.service.ts
@@ -1,46 +1,81 @@
-import { Injectable, TemplateRef } from '@angular/core';
+import { ComponentFactory, Injectable, TemplateRef } from '@angular/core';
 import { OutletPosition } from './outlet.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class OutletService {
-  private templatesRefs = {};
-  private templatesRefsBefore = {};
-  private templatesRefsAfter = {};
+  private templatesRefs = new Map<
+    string,
+    TemplateRef<any> | ComponentFactory<any>
+  >();
+  private templatesRefsBefore = new Map<
+    string,
+    TemplateRef<any> | ComponentFactory<any>
+  >();
+  private templatesRefsAfter = new Map<
+    string,
+    TemplateRef<any> | ComponentFactory<any>
+  >();
 
+  /**
+   * Adds a template or ComponentFactory, so that UI outlets can be replaced dynamically.
+   * The UI position where this template or ComponentFactory is inserted is given by a
+   * string reference (called `outlet`) and optional `OutletPosition`. The `OutletPosition`
+   * is either before or after, or replaces the entire UI.
+   *
+   * @param outlet the UI location represented by a string
+   * @param template the `TemplateRef` that will be used to insert UI
+   * @param position the `OutletPosition` in the UI
+   */
   add(
     outlet: string,
     template: TemplateRef<any>,
+    position?: OutletPosition
+  ): void;
+  /**
+   * @param factory The `ComponentFactory` that will be dynamically added to the outlet UI
+   */
+  add(
+    outlet: string,
+    // tslint:disable-next-line: unified-signatures
+    factory: ComponentFactory<any>,
+    position?: OutletPosition
+  ): void;
+  /**
+   * @param templateOrFactory A `ComponentFactory` that inserts a component dynamically.
+   */
+  add(
+    outlet: string,
+    templateOrFactory: TemplateRef<any> | ComponentFactory<any>,
     position: OutletPosition = OutletPosition.REPLACE
   ): void {
     if (position === OutletPosition.BEFORE) {
-      this.templatesRefsBefore[outlet] = template;
+      this.templatesRefsBefore.set(outlet, templateOrFactory);
     }
     if (position === OutletPosition.REPLACE) {
-      this.templatesRefs[outlet] = template;
+      this.templatesRefs.set(outlet, templateOrFactory);
     }
     if (position === OutletPosition.AFTER) {
-      this.templatesRefsAfter[outlet] = template;
+      this.templatesRefsAfter.set(outlet, templateOrFactory);
     }
   }
 
   get(
     outlet: string,
     position: OutletPosition = OutletPosition.REPLACE
-  ): TemplateRef<any> {
+  ): TemplateRef<any> | ComponentFactory<any> {
     let templateRef;
     switch (position) {
       case OutletPosition.BEFORE:
-        templateRef = this.templatesRefsBefore[outlet];
+        templateRef = this.templatesRefsBefore.get(outlet);
         break;
       case OutletPosition.AFTER:
-        templateRef = this.templatesRefsAfter[outlet];
+        templateRef = this.templatesRefsAfter.get(outlet);
         break;
       default:
-        templateRef = this.templatesRefs[outlet];
+        templateRef = this.templatesRefs.get(outlet);
     }
     return templateRef;
-    // return this.templatesRefs[outlet] ? this.templatesRefs[outlet] : null;
   }
 }


### PR DESCRIPTION
Similar to the dynamic creation of CMS components, you can add components instantly to an outlet position. 

closes #5355