### PR TITLE
Introduce cx-storefront, cx-header and cx-footer outlet

### DIFF
--- a/projects/storefrontlib/src/layout/main/main.module.ts
+++ b/projects/storefrontlib/src/layout/main/main.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { FeaturesConfigModule } from '@spartacus/core';
 import { GlobalMessageComponentModule } from '../../cms-components/misc/global-message/global-message.module';
-import { OutletRefModule } from '../../cms-structure/outlet/outlet-ref/outlet-ref.module';
+import { OutletModule, OutletRefModule } from '../../cms-structure/index';
 import { PageLayoutModule } from '../../cms-structure/page/page-layout/page-layout.module';
 import { PageSlotModule } from '../../cms-structure/page/slot/page-slot.module';
 import { PwaModule } from '../../cms-structure/pwa/pwa.module';
@@ -16,6 +16,7 @@ import { StorefrontComponent } from './storefront.component';
     CommonModule,
     RouterModule,
     GlobalMessageComponentModule,
+    OutletModule,
     OutletRefModule,
     PwaModule,
     PageLayoutModule,

--- a/projects/storefrontlib/src/layout/main/storefront.component.html
+++ b/projects/storefrontlib/src/layout/main/storefront.component.html
@@ -1,19 +1,23 @@
-<cx-page-slot position="TopHeaderSlot"></cx-page-slot>
-<header
-  [class.is-expanded]="isExpanded$ | async"
-  (keydown.escape)="collapseMenu()"
-  (click)="collapseMenuIfClickOutside($event)"
->
-  <cx-page-layout section="header"></cx-page-layout>
-  <cx-page-layout section="navigation"></cx-page-layout>
-</header>
+<ng-template cxOutlet="cx-storefront">
+  <ng-template cxOutlet="cx-header">
+    <cx-page-slot position="TopHeaderSlot"></cx-page-slot>
+    <header
+      [class.is-expanded]="isExpanded$ | async"
+      (keydown.escape)="collapseMenu()"
+      (click)="collapseMenuIfClickOutside($event)"
+    >
+      <cx-page-layout section="header"></cx-page-layout>
+      <cx-page-layout section="navigation"></cx-page-layout>
+    </header>
+    <cx-page-slot position="BottomHeaderSlot"></cx-page-slot>
+    <cx-global-message></cx-global-message>
+  </ng-template>
 
-<cx-page-slot position="BottomHeaderSlot"></cx-page-slot>
+  <router-outlet></router-outlet>
 
-<cx-global-message></cx-global-message>
-
-<router-outlet></router-outlet>
-
-<footer>
-  <cx-page-layout section="footer"></cx-page-layout>
-</footer>
+  <ng-template cxOutlet="cx-footer">
+    <footer>
+      <cx-page-layout section="footer"></cx-page-layout>
+    </footer>
+  </ng-template>
+</ng-template>


### PR DESCRIPTION
With this PR you can change the UI of the overall storefront, header and footer by adding an `ng-template` for these outlet references:
- `cx-storefront`
- `cx-header`
- `cx-footer`

You can use these outlet references to create additional UI :
```html
<ng-template cxOutletRef="cx-header" cxOutletPos="after">
  Custom UI for the header
</ng-template>
```
closes #5357 