### PR TITLE
feat: Entity processes loader

### DIFF
--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-group.actions.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-group.actions.ts
@@ -1,0 +1,2 @@
+import * as StateEntityProcessesLoaderActions from './entity-processes-loader.action';
+export { StateEntityProcessesLoaderActions };

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-group.selectors.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-group.selectors.ts
@@ -1,0 +1,2 @@
+import * as StateEntityProcessesLoaderSelectors from './entity-processes-loader.selectors';
+export { StateEntityProcessesLoaderSelectors };

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-state.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-state.ts
@@ -1,0 +1,6 @@
+import { EntityState } from '../entity/entity-state';
+import { ProcessesLoaderState } from '../processes-loader/processes-loader-state';
+
+export type EntityProcessesLoaderState<T> = EntityState<
+  ProcessesLoaderState<T>
+>;

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.spec.ts
@@ -1,18 +1,18 @@
 import {
   processesDecrementMeta,
   processesIncrementMeta,
-  processesResetMeta,
+  processesLoaderResetMeta,
 } from '../processes-loader/processes-loader.action';
 import {
   EntityProcessesDecrementAction,
   entityProcessesDecrementMeta,
   EntityProcessesIncrementAction,
   entityProcessesIncrementMeta,
-  EntityProcessesResetAction,
-  entityProcessesResetMeta,
+  EntityProcessesLoaderResetAction,
+  entityProcessesLoaderResetMeta,
   ENTITY_PROCESSES_DECREMENT_ACTION,
   ENTITY_PROCESSES_INCREMENT_ACTION,
-  ENTITY_PROCESSES_RESET_ACTION,
+  ENTITY_PROCESSES_LOADER_RESET_ACTION,
 } from './entity-processes-loader.action';
 
 describe('EntityProcessesLoader Actions', () => {
@@ -48,13 +48,16 @@ describe('EntityProcessesLoader Actions', () => {
 
     describe('EntityProcessesResetAction', () => {
       it('should create an action', () => {
-        const action = new EntityProcessesResetAction(
+        const action = new EntityProcessesLoaderResetAction(
           TEST_ENTITY_TYPE,
           TEST_ENTITY_ID
         );
         expect({ ...action }).toEqual({
-          type: ENTITY_PROCESSES_RESET_ACTION,
-          meta: entityProcessesResetMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
+          type: ENTITY_PROCESSES_LOADER_RESET_ACTION,
+          meta: entityProcessesLoaderResetMeta(
+            TEST_ENTITY_TYPE,
+            TEST_ENTITY_ID
+          ),
         });
       });
     });
@@ -89,9 +92,12 @@ describe('EntityProcessesLoader Actions', () => {
 
     describe('entityProcessesResetMeta', () => {
       it('should create a meta', () => {
-        const meta = entityProcessesResetMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const meta = entityProcessesLoaderResetMeta(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
         expect(meta).toEqual({
-          ...processesResetMeta(TEST_ENTITY_TYPE),
+          ...processesLoaderResetMeta(TEST_ENTITY_TYPE),
           entityId: TEST_ENTITY_ID,
         });
       });

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.spec.ts
@@ -1,18 +1,18 @@
 import {
-  popMeta,
+  processesDecrementMeta,
+  processesIncrementMeta,
   processesResetMeta,
-  pushMeta,
 } from '../processes-loader/processes-loader.action';
 import {
-  EntityPopAction,
-  entityPopMeta,
+  EntityProcessesDecrementAction,
+  entityProcessesDecrementMeta,
+  EntityProcessesIncrementAction,
+  entityProcessesIncrementMeta,
   EntityProcessesResetAction,
   entityProcessesResetMeta,
-  EntityPushAction,
-  entityPushMeta,
-  ENTITY_POP_ACTION,
+  ENTITY_PROCESSES_DECREMENT_ACTION,
+  ENTITY_PROCESSES_INCREMENT_ACTION,
   ENTITY_PROCESSES_RESET_ACTION,
-  ENTITY_PUSH_ACTION,
 } from './entity-processes-loader.action';
 
 describe('EntityProcessesLoader Actions', () => {
@@ -20,22 +20,28 @@ describe('EntityProcessesLoader Actions', () => {
   const TEST_ENTITY_ID = 'testId';
 
   describe('Action creators', () => {
-    describe('EntityPushAction', () => {
+    describe('EntityProcessesIncrementAction', () => {
       it('should create an action', () => {
-        const action = new EntityPushAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const action = new EntityProcessesIncrementAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
         expect({ ...action }).toEqual({
-          type: ENTITY_PUSH_ACTION,
-          meta: entityPushMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
+          type: ENTITY_PROCESSES_INCREMENT_ACTION,
+          meta: entityProcessesIncrementMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
         });
       });
     });
 
-    describe('EntityPopAction', () => {
+    describe('EntityProcessesDecrementAction', () => {
       it('should create an action', () => {
-        const action = new EntityPopAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const action = new EntityProcessesDecrementAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
         expect({ ...action }).toEqual({
-          type: ENTITY_POP_ACTION,
-          meta: entityPopMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
+          type: ENTITY_PROCESSES_DECREMENT_ACTION,
+          meta: entityProcessesDecrementMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
         });
       });
     });
@@ -55,21 +61,27 @@ describe('EntityProcessesLoader Actions', () => {
   });
 
   describe('meta creators', () => {
-    describe('entityPushMeta', () => {
+    describe('entityProcessesIncrementMeta', () => {
       it('should create a meta', () => {
-        const meta = entityPushMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const meta = entityProcessesIncrementMeta(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
         expect(meta).toEqual({
-          ...pushMeta(TEST_ENTITY_TYPE),
+          ...processesIncrementMeta(TEST_ENTITY_TYPE),
           entityId: TEST_ENTITY_ID,
         });
       });
     });
 
-    describe('entityPopMeta', () => {
+    describe('entityProcessesDecrementMeta', () => {
       it('should create a meta', () => {
-        const meta = entityPopMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const meta = entityProcessesDecrementMeta(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
         expect(meta).toEqual({
-          ...popMeta(TEST_ENTITY_TYPE),
+          ...processesDecrementMeta(TEST_ENTITY_TYPE),
           entityId: TEST_ENTITY_ID,
         });
       });

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.spec.ts
@@ -1,0 +1,88 @@
+import {
+  popMeta,
+  processesResetMeta,
+  pushMeta,
+} from '../processes-loader/processes-loader.action';
+import {
+  EntityPopAction,
+  entityPopMeta,
+  EntityProcessesResetAction,
+  entityProcessesResetMeta,
+  EntityPushAction,
+  entityPushMeta,
+  ENTITY_POP_ACTION,
+  ENTITY_PROCESSES_RESET_ACTION,
+  ENTITY_PUSH_ACTION,
+} from './entity-processes-loader.action';
+
+describe('EntityProcessesLoader Actions', () => {
+  const TEST_ENTITY_TYPE = 'test';
+  const TEST_ENTITY_ID = 'testId';
+
+  describe('Action creators', () => {
+    describe('EntityPushAction', () => {
+      it('should create an action', () => {
+        const action = new EntityPushAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        expect({ ...action }).toEqual({
+          type: ENTITY_PUSH_ACTION,
+          meta: entityPushMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
+        });
+      });
+    });
+
+    describe('EntityPopAction', () => {
+      it('should create an action', () => {
+        const action = new EntityPopAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        expect({ ...action }).toEqual({
+          type: ENTITY_POP_ACTION,
+          meta: entityPopMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
+        });
+      });
+    });
+
+    describe('EntityProcessesResetAction', () => {
+      it('should create an action', () => {
+        const action = new EntityProcessesResetAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
+        expect({ ...action }).toEqual({
+          type: ENTITY_PROCESSES_RESET_ACTION,
+          meta: entityProcessesResetMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID),
+        });
+      });
+    });
+  });
+
+  describe('meta creators', () => {
+    describe('entityPushMeta', () => {
+      it('should create a meta', () => {
+        const meta = entityPushMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        expect(meta).toEqual({
+          ...pushMeta(TEST_ENTITY_TYPE),
+          entityId: TEST_ENTITY_ID,
+        });
+      });
+    });
+
+    describe('entityPopMeta', () => {
+      it('should create a meta', () => {
+        const meta = entityPopMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        expect(meta).toEqual({
+          ...popMeta(TEST_ENTITY_TYPE),
+          entityId: TEST_ENTITY_ID,
+        });
+      });
+    });
+
+    describe('entityProcessesResetMeta', () => {
+      it('should create a meta', () => {
+        const meta = entityProcessesResetMeta(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        expect(meta).toEqual({
+          ...processesResetMeta(TEST_ENTITY_TYPE),
+          entityId: TEST_ENTITY_ID,
+        });
+      });
+    });
+  });
+});

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
@@ -4,10 +4,11 @@ import {
   processesDecrementMeta,
   processesIncrementMeta,
   ProcessesLoaderMeta,
-  processesResetMeta,
+  processesLoaderResetMeta,
 } from '../processes-loader/processes-loader.action';
 
-export const ENTITY_PROCESSES_RESET_ACTION = '[ENTITY] PROCESSES RESET';
+export const ENTITY_PROCESSES_LOADER_RESET_ACTION =
+  '[ENTITY] PROCESSES LOADER RESET';
 export const ENTITY_PROCESSES_INCREMENT_ACTION = '[ENTITY] PROCESSES INCREMENT';
 export const ENTITY_PROCESSES_DECREMENT_ACTION = '[ENTITY] PROCESSES DECREMENT';
 
@@ -20,12 +21,12 @@ export interface EntityProcessesLoaderAction extends Action {
   readonly meta?: EntityProcessesLoaderMeta;
 }
 
-export function entityProcessesResetMeta(
+export function entityProcessesLoaderResetMeta(
   entityType: string,
   id: string | string[]
 ): EntityProcessesLoaderMeta {
   return {
-    ...processesResetMeta(entityType),
+    ...processesLoaderResetMeta(entityType),
     ...entityMeta(entityType, id),
   };
 }
@@ -50,11 +51,12 @@ export function entityProcessesDecrementMeta(
   };
 }
 
-export class EntityProcessesResetAction implements EntityProcessesLoaderAction {
-  type = ENTITY_PROCESSES_RESET_ACTION;
+export class EntityProcessesLoaderResetAction
+  implements EntityProcessesLoaderAction {
+  type = ENTITY_PROCESSES_LOADER_RESET_ACTION;
   readonly meta: EntityProcessesLoaderMeta;
   constructor(entityType: string, id: string | string[]) {
-    this.meta = entityProcessesResetMeta(entityType, id);
+    this.meta = entityProcessesLoaderResetMeta(entityType, id);
   }
 }
 

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
@@ -1,15 +1,15 @@
 import { Action } from '@ngrx/store';
 import { entityMeta, EntityMeta } from '../entity/entity.action';
 import {
-  popMeta,
+  processesDecrementMeta,
+  processesIncrementMeta,
   ProcessesLoaderMeta,
   processesResetMeta,
-  pushMeta,
 } from '../processes-loader/processes-loader.action';
 
 export const ENTITY_PROCESSES_RESET_ACTION = '[ENTITY] PROCESSES RESET';
-export const ENTITY_PUSH_ACTION = '[ENTITY] PUSH';
-export const ENTITY_POP_ACTION = '[ENTITY] POP';
+export const ENTITY_PROCESSES_INCREMENT_ACTION = '[ENTITY] PROCESSES INCREMENT';
+export const ENTITY_PROCESSES_DECREMENT_ACTION = '[ENTITY] PROCESSES DECREMENT';
 
 export interface EntityProcessesLoaderMeta
   extends EntityMeta,
@@ -30,22 +30,22 @@ export function entityProcessesResetMeta(
   };
 }
 
-export function entityPushMeta(
+export function entityProcessesIncrementMeta(
   entityType: string,
   id: string | string[]
 ): EntityProcessesLoaderMeta {
   return {
-    ...pushMeta(entityType),
+    ...processesIncrementMeta(entityType),
     ...entityMeta(entityType, id),
   };
 }
 
-export function entityPopMeta(
+export function entityProcessesDecrementMeta(
   entityType: string,
   id: string | string[]
 ): EntityProcessesLoaderMeta {
   return {
-    ...popMeta(entityType),
+    ...processesDecrementMeta(entityType),
     ...entityMeta(entityType, id),
   };
 }
@@ -58,18 +58,20 @@ export class EntityProcessesResetAction implements EntityProcessesLoaderAction {
   }
 }
 
-export class EntityPushAction implements EntityProcessesLoaderAction {
-  type = ENTITY_PUSH_ACTION;
+export class EntityProcessesIncrementAction
+  implements EntityProcessesLoaderAction {
+  type = ENTITY_PROCESSES_INCREMENT_ACTION;
   readonly meta: EntityProcessesLoaderMeta;
   constructor(entityType: string, id: string | string[]) {
-    this.meta = entityPushMeta(entityType, id);
+    this.meta = entityProcessesIncrementMeta(entityType, id);
   }
 }
 
-export class EntityPopAction implements EntityProcessesLoaderAction {
-  type = ENTITY_POP_ACTION;
+export class EntityProcessesDecrementAction
+  implements EntityProcessesLoaderAction {
+  type = ENTITY_PROCESSES_DECREMENT_ACTION;
   readonly meta: EntityProcessesLoaderMeta;
   constructor(entityType: string, id: string | string[]) {
-    this.meta = entityPopMeta(entityType, id);
+    this.meta = entityProcessesDecrementMeta(entityType, id);
   }
 }

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
@@ -1,0 +1,75 @@
+import { Action } from '@ngrx/store';
+import { entityMeta, EntityMeta } from '../entity/entity.action';
+import {
+  popMeta,
+  ProcessesLoaderMeta,
+  processesResetMeta,
+  pushMeta,
+} from '../processes-loader/processes-loader.action';
+
+export const ENTITY_PROCESSES_RESET_ACTION = '[ENTITY] PROCESSES RESET';
+export const ENTITY_PUSH_ACTION = '[ENTITY] PUSH';
+export const ENTITY_POP_ACTION = '[ENTITY] POP';
+
+export interface EntityProcessesLoaderMeta
+  extends EntityMeta,
+    ProcessesLoaderMeta {}
+
+export interface EntityProcessesLoaderAction extends Action {
+  readonly payload?: any;
+  readonly meta?: EntityProcessesLoaderMeta;
+}
+
+export function entityProcessesResetMeta(
+  entityType: string,
+  id: string | string[]
+): EntityProcessesLoaderMeta {
+  return {
+    ...processesResetMeta(entityType),
+    ...entityMeta(entityType, id),
+  };
+}
+
+export function entityPushMeta(
+  entityType: string,
+  id: string | string[]
+): EntityProcessesLoaderMeta {
+  return {
+    ...pushMeta(entityType),
+    ...entityMeta(entityType, id),
+  };
+}
+
+export function entityPopMeta(
+  entityType: string,
+  id: string | string[]
+): EntityProcessesLoaderMeta {
+  return {
+    ...popMeta(entityType),
+    ...entityMeta(entityType, id),
+  };
+}
+
+export class EntityProcessesResetAction implements EntityProcessesLoaderAction {
+  type = ENTITY_PROCESSES_RESET_ACTION;
+  readonly meta: EntityProcessesLoaderMeta;
+  constructor(entityType: string, id: string | string[]) {
+    this.meta = entityProcessesResetMeta(entityType, id);
+  }
+}
+
+export class EntityPushAction implements EntityProcessesLoaderAction {
+  type = ENTITY_PUSH_ACTION;
+  readonly meta: EntityProcessesLoaderMeta;
+  constructor(entityType: string, id: string | string[]) {
+    this.meta = entityPushMeta(entityType, id);
+  }
+}
+
+export class EntityPopAction implements EntityProcessesLoaderAction {
+  type = ENTITY_POP_ACTION;
+  readonly meta: EntityProcessesLoaderMeta;
+  constructor(entityType: string, id: string | string[]) {
+    this.meta = entityPopMeta(entityType, id);
+  }
+}

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.spec.ts
@@ -4,7 +4,7 @@ import { initialProcessesState } from '../processes-loader';
 import {
   EntityProcessesDecrementAction,
   EntityProcessesIncrementAction,
-  EntityProcessesResetAction,
+  EntityProcessesLoaderResetAction,
 } from './entity-processes-loader.action';
 import { entityProcessesLoaderReducer } from './entity-processes-loader.reducer';
 
@@ -78,9 +78,9 @@ describe('EntityProcessesLoader reducer', () => {
       });
     });
 
-    describe('RESET ACTION', () => {
+    describe('PROCESSES LOADER RESET ACTION', () => {
       it('should reset processes loader state', () => {
-        const action = new EntityProcessesResetAction(
+        const action = new EntityProcessesLoaderResetAction(
           TEST_ENTITY_TYPE,
           TEST_ENTITY_ID
         );
@@ -183,9 +183,9 @@ describe('EntityProcessesLoader reducer', () => {
       });
     });
 
-    describe('RESET ACTION', () => {
+    describe('PROCESSES LOADER RESET ACTION', () => {
       it('should reset processes loader state', () => {
-        const action = new EntityProcessesResetAction(
+        const action = new EntityProcessesLoaderResetAction(
           TEST_ENTITY_TYPE,
           TEST_ENTITIES_ID
         );

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.spec.ts
@@ -1,0 +1,233 @@
+import { initialLoaderState } from '@spartacus/core';
+import { initialEntityState } from '../entity/entity.reducer';
+import { initialProcessesState } from '../processes-loader';
+import {
+  EntityPopAction,
+  EntityProcessesResetAction,
+  EntityPushAction,
+} from './entity-processes-loader.action';
+import { entityProcessesLoaderReducer } from './entity-processes-loader.reducer';
+
+describe('EntityProcessesLoader reducer', () => {
+  const TEST_ENTITY_TYPE = 'test';
+
+  describe('undefined action', () => {
+    it('should return the default state', () => {
+      const action = {} as any;
+      const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
+        undefined,
+        action
+      );
+
+      const expectedState = initialEntityState;
+
+      expect(state).toEqual(expectedState);
+    });
+  });
+
+  describe('single entity', () => {
+    const TEST_ENTITY_ID = 'testId';
+
+    describe('PUSH ACTION', () => {
+      it('should increment processesCount state', () => {
+        const action = new EntityPushAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
+          undefined,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITY_ID]: {
+              processesCount: 1,
+              loading: false,
+              error: false,
+              success: false,
+              value: undefined,
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+
+    describe('POP ACTION', () => {
+      it('should increment processesCount state', () => {
+        const action = new EntityPopAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
+          undefined,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITY_ID]: {
+              processesCount: -1,
+              loading: false,
+              error: false,
+              success: false,
+              value: undefined,
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+
+    describe('RESET ACTION', () => {
+      it('should reset processes loader state', () => {
+        const action = new EntityProcessesResetAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
+        const initialState = {
+          entities: {
+            [TEST_ENTITY_ID]: {
+              processesCount: 2,
+              loading: false,
+              error: false,
+              success: true,
+              value: 'data',
+            },
+          },
+        };
+
+        const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
+          initialState,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITY_ID]: {
+              processesCount: 0,
+              loading: false,
+              error: false,
+              success: false,
+              value: undefined,
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+  });
+
+  describe('multiple entities', () => {
+    const TEST_ENTITIES_ID = ['test1', 'test2'];
+
+    describe('PUSH ACTION', () => {
+      it('should increment processesCount state', () => {
+        const action = new EntityPushAction(TEST_ENTITY_TYPE, TEST_ENTITIES_ID);
+        const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
+          undefined,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITIES_ID[0]]: {
+              processesCount: 1,
+              loading: false,
+              error: false,
+              success: false,
+              value: undefined,
+            },
+            [TEST_ENTITIES_ID[1]]: {
+              processesCount: 1,
+              loading: false,
+              error: false,
+              success: false,
+              value: undefined,
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+
+    describe('POP ACTION', () => {
+      it('should decrement processesCount state', () => {
+        const action = new EntityPopAction(TEST_ENTITY_TYPE, TEST_ENTITIES_ID);
+        const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
+          undefined,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITIES_ID[0]]: {
+              processesCount: -1,
+              loading: false,
+              error: false,
+              success: false,
+              value: undefined,
+            },
+            [TEST_ENTITIES_ID[1]]: {
+              processesCount: -1,
+              loading: false,
+              error: false,
+              success: false,
+              value: undefined,
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+
+    describe('RESET ACTION', () => {
+      it('should reset processes loader state', () => {
+        const action = new EntityProcessesResetAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITIES_ID
+        );
+        const initialState = {
+          entities: {
+            [TEST_ENTITIES_ID[0]]: {
+              processesCount: 2,
+              loading: false,
+              error: false,
+              success: true,
+              value: 'data1',
+            },
+            [TEST_ENTITIES_ID[1]]: {
+              processesCount: 3,
+              loading: false,
+              error: false,
+              success: true,
+              value: 'data2',
+            },
+            'another entity': {
+              processesCount: 2,
+              loading: false,
+              error: false,
+              success: true,
+              value: 'data3',
+            },
+          },
+        };
+
+        const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
+          initialState,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITIES_ID[0]]: {
+              ...initialProcessesState,
+              ...initialLoaderState,
+            },
+            [TEST_ENTITIES_ID[1]]: {
+              ...initialProcessesState,
+              ...initialLoaderState,
+            },
+            'another entity': {
+              processesCount: 2,
+              loading: false,
+              error: false,
+              success: true,
+              value: 'data3',
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+  });
+});

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.spec.ts
@@ -2,9 +2,9 @@ import { initialLoaderState } from '@spartacus/core';
 import { initialEntityState } from '../entity/entity.reducer';
 import { initialProcessesState } from '../processes-loader';
 import {
-  EntityPopAction,
+  EntityProcessesDecrementAction,
+  EntityProcessesIncrementAction,
   EntityProcessesResetAction,
-  EntityPushAction,
 } from './entity-processes-loader.action';
 import { entityProcessesLoaderReducer } from './entity-processes-loader.reducer';
 
@@ -28,9 +28,12 @@ describe('EntityProcessesLoader reducer', () => {
   describe('single entity', () => {
     const TEST_ENTITY_ID = 'testId';
 
-    describe('PUSH ACTION', () => {
+    describe('PROCESSES INCREMENT ACTION', () => {
       it('should increment processesCount state', () => {
-        const action = new EntityPushAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const action = new EntityProcessesIncrementAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
         const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
           undefined,
           action
@@ -50,9 +53,12 @@ describe('EntityProcessesLoader reducer', () => {
       });
     });
 
-    describe('POP ACTION', () => {
+    describe('PROCESSES DECREMENT ACTION', () => {
       it('should increment processesCount state', () => {
-        const action = new EntityPopAction(TEST_ENTITY_TYPE, TEST_ENTITY_ID);
+        const action = new EntityProcessesDecrementAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
         const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
           undefined,
           action
@@ -113,9 +119,12 @@ describe('EntityProcessesLoader reducer', () => {
   describe('multiple entities', () => {
     const TEST_ENTITIES_ID = ['test1', 'test2'];
 
-    describe('PUSH ACTION', () => {
+    describe('PROCESSES INCREMENT ACTION', () => {
       it('should increment processesCount state', () => {
-        const action = new EntityPushAction(TEST_ENTITY_TYPE, TEST_ENTITIES_ID);
+        const action = new EntityProcessesIncrementAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITIES_ID
+        );
         const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
           undefined,
           action
@@ -142,9 +151,12 @@ describe('EntityProcessesLoader reducer', () => {
       });
     });
 
-    describe('POP ACTION', () => {
+    describe('PROCESSES DECREMENT ACTION', () => {
       it('should decrement processesCount state', () => {
-        const action = new EntityPopAction(TEST_ENTITY_TYPE, TEST_ENTITIES_ID);
+        const action = new EntityProcessesDecrementAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITIES_ID
+        );
         const state = entityProcessesLoaderReducer(TEST_ENTITY_TYPE)(
           undefined,
           action

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.ts
@@ -1,0 +1,19 @@
+import { entityReducer } from '../entity/entity.reducer';
+import { processesLoaderReducer } from '../processes-loader';
+import { ProcessesLoaderAction } from '../processes-loader/processes-loader.action';
+import { EntityProcessesLoaderState } from './entity-processes-loader-state';
+import { EntityProcessesLoaderAction } from './entity-processes-loader.action';
+
+/**
+ * Higher order reducer that wraps ProcessesLoaderReducer and EntityReducer enhancing
+ * single state reducer to support multiple entities with generic processesCount flag
+ */
+export function entityProcessesLoaderReducer<T>(
+  entityType: string,
+  reducer?: (state: T, action: ProcessesLoaderAction) => T
+): (
+  state: EntityProcessesLoaderState<T>,
+  action: EntityProcessesLoaderAction
+) => EntityProcessesLoaderState<T> {
+  return entityReducer(entityType, processesLoaderReducer(entityType, reducer));
+}

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.spec.ts
@@ -2,6 +2,7 @@ import { EntityProcessesLoaderState } from './entity-processes-loader-state';
 import {
   entityHasPendingProcessesSelector,
   entityIsStableSelector,
+  entityProcessesLoaderStateSelector,
 } from './entity-processes-loader.selectors';
 
 describe('EntityProcessesLoader selectors', () => {
@@ -69,6 +70,38 @@ describe('EntityProcessesLoader selectors', () => {
       };
       const value = entityHasPendingProcessesSelector(TestState, testId);
       expect(value).toBe(false);
+    });
+  });
+
+  describe('entityProcessesLoaderStateSelector', () => {
+    it('should return entity when it exists', () => {
+      const TestState: EntityProcessesLoaderState<string> = {
+        entities: {
+          [testId]: {
+            processesCount: 0,
+            loading: false,
+            error: false,
+            value: 'test-value',
+            success: true,
+          },
+        },
+      };
+      const value = entityProcessesLoaderStateSelector(TestState, testId);
+      expect(value).toBe(TestState.entities[testId]);
+    });
+
+    it('should return initialProcessesState with initialLoaderState', () => {
+      const TestState: EntityProcessesLoaderState<string> = {
+        entities: {},
+      };
+      const value = entityProcessesLoaderStateSelector(TestState, testId);
+      expect(value).toEqual({
+        loading: false,
+        error: false,
+        success: false,
+        value: undefined,
+        processesCount: 0,
+      });
     });
   });
 });

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.spec.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.spec.ts
@@ -1,0 +1,74 @@
+import { EntityProcessesLoaderState } from './entity-processes-loader-state';
+import {
+  entityHasPendingProcessesSelector,
+  entityIsStableSelector,
+} from './entity-processes-loader.selectors';
+
+describe('EntityProcessesLoader selectors', () => {
+  const testId = 'testId';
+
+  describe('entityIsStableSelector', () => {
+    it('should return true when there are no processes and no loading', () => {
+      const TestState: EntityProcessesLoaderState<string> = {
+        entities: {
+          [testId]: {
+            processesCount: 0,
+            loading: false,
+          },
+        },
+      };
+      const value = entityIsStableSelector(TestState, testId);
+      expect(value).toBe(true);
+    });
+
+    it('should return false when there are pending processes', () => {
+      const TestState: EntityProcessesLoaderState<string> = {
+        entities: {
+          [testId]: {
+            processesCount: 1,
+          },
+        },
+      };
+      const value = entityIsStableSelector(TestState, testId);
+      expect(value).toBe(false);
+    });
+
+    it('should return false when there are loading', () => {
+      const TestState: EntityProcessesLoaderState<string> = {
+        entities: {
+          [testId]: {
+            loading: true,
+          },
+        },
+      };
+      const value = entityIsStableSelector(TestState, testId);
+      expect(value).toBe(false);
+    });
+  });
+
+  describe('entityHasPendingProcessesSelector', () => {
+    it('should return true when there are pending processes', () => {
+      const TestState: EntityProcessesLoaderState<string> = {
+        entities: {
+          [testId]: {
+            processesCount: 2,
+          },
+        },
+      };
+      const value = entityHasPendingProcessesSelector(TestState, testId);
+      expect(value).toBe(true);
+    });
+
+    it('should return false when there are no pending processes', () => {
+      const TestState: EntityProcessesLoaderState<string> = {
+        entities: {
+          [testId]: {
+            processesCount: 0,
+          },
+        },
+      };
+      const value = entityHasPendingProcessesSelector(TestState, testId);
+      expect(value).toBe(false);
+    });
+  });
+});

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.ts
@@ -1,0 +1,22 @@
+import { entityStateSelector } from '../entity-loader/entity-loader.selectors';
+import {
+  hasPendingProcessesSelector,
+  isStableSelector,
+} from '../processes-loader/processes-loader.selectors';
+import { EntityProcessesLoaderState } from './entity-processes-loader-state';
+
+export function entityHasPendingProcessesSelector<T>(
+  state: EntityProcessesLoaderState<T>,
+  id: string
+): boolean {
+  const entityState = entityStateSelector(state, id);
+  return hasPendingProcessesSelector(entityState);
+}
+
+export function entityIsStableSelector<T>(
+  state: EntityProcessesLoaderState<T>,
+  id: string
+): boolean {
+  const entityState = entityStateSelector(state, id);
+  return isStableSelector(entityState);
+}

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.ts
@@ -1,4 +1,9 @@
 import { entityStateSelector } from '../entity-loader/entity-loader.selectors';
+import { initialLoaderState } from '../loader/loader.reducer';
+import {
+  initialProcessesState,
+  ProcessesLoaderState,
+} from '../processes-loader';
 import {
   hasPendingProcessesSelector,
   isStableSelector,
@@ -19,4 +24,13 @@ export function entityIsStableSelector<T>(
 ): boolean {
   const entityState = entityStateSelector(state, id);
   return isStableSelector(entityState);
+}
+
+export function entityProcessesLoaderStateSelector<T>(
+  state: EntityProcessesLoaderState<T>,
+  id: string
+): ProcessesLoaderState<T> {
+  return (
+    state.entities[id] || { ...initialLoaderState, ...initialProcessesState }
+  );
 }

--- a/projects/core/src/state/utils/entity-processes-loader/index.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/index.ts
@@ -1,0 +1,4 @@
+export * from './entity-processes-loader-group.actions';
+export * from './entity-processes-loader-group.selectors';
+export * from './entity-processes-loader-state';
+export * from './entity-processes-loader.reducer';

--- a/projects/core/src/state/utils/index.ts
+++ b/projects/core/src/state/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './entity-loader/index';
+export * from './entity-processes-loader/index';
 export * from './entity/index';
 export { getStateSlice } from './get-state-slice';
 export * from './loader/index';


### PR DESCRIPTION
Further work based on #5530 

Build on top of ProcessesLoader. You can now apply it with entities.

Required to support processes count for multicart handling.


Closes #5531 