### PR TITLE
fix: missing exports of services for site auto-config (for 1.3.1)

### DIFF
--- a/projects/core/src/occ/config-loader/index.ts
+++ b/projects/core/src/occ/config-loader/index.ts
@@ -1,4 +1,6 @@
 export * from './java-reg-exp-converter';
 export { OccConfigLoaderModule } from './occ-config-loader.module';
+export * from './occ-config-loader.service';
 export * from './occ-loaded-config';
 export * from './occ-loaded-config-converter';
+export * from './occ-sites-config-loader';


### PR DESCRIPTION
OccConfigLoaderService
OccSitesConfigLoader

closes GH-5570