### PR TITLE
fix: Retries for checkout details call

### DIFF
--- a/projects/core/src/occ/adapters/checkout/occ-checkout.adapter.ts
+++ b/projects/core/src/occ/adapters/checkout/occ-checkout.adapter.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { retry } from 'rxjs/operators';
 import { CheckoutAdapter } from '../../../checkout/connectors/checkout/checkout.adapter';
 import { ORDER_NORMALIZER } from '../../../checkout/connectors/checkout/converters';
 import { CheckoutDetails } from '../../../checkout/models/checkout.model';
@@ -22,6 +23,9 @@ const CARTS_ENDPOINT = '/carts/';
 
 @Injectable()
 export class OccCheckoutAdapter implements CheckoutAdapter {
+  // ! Default number of retries for failed requests
+  private RETRY_ATTEMPTS = 3;
+
   constructor(
     protected http: HttpClient,
     protected occEndpoints: OccEndpointsService,
@@ -59,7 +63,9 @@ export class OccCheckoutAdapter implements CheckoutAdapter {
     const params = new HttpParams({
       fromString: `fields=${CHECKOUT_PARAMS}`,
     });
-    return this.http.get<CheckoutDetails>(url, { params });
+    return this.http
+      .get<CheckoutDetails>(url, { params })
+      .pipe(retry(this.RETRY_ATTEMPTS));
   }
 
   clearCheckoutDeliveryAddress(


### PR DESCRIPTION
The thing that prevented going to the second step of the checkout was failed requests for checkout details. There wasn't any retry mechanism and once it failed component kept waiting for checkout data, but it was never fetched.

This is a quick fix. Better queuing for cart requests should be implemented to avoid `Jalo` errors and help with race conditions issues. For now, the retry mechanism is the easiest way to help with this issue.

Closes #5632 