### PR TITLE
COL-212 Use brandCode as category in merchandising carousel

### DIFF
--- a/projects/cds/src/merchandising/facade/cds-merchandising-user-context.service.spec.ts
+++ b/projects/cds/src/merchandising/facade/cds-merchandising-user-context.service.spec.ts
@@ -104,7 +104,6 @@ describe('CdsMerchandisingUserContextService', () => {
   it('should return a valid MerchandisingUserContext object, if there are no facets, but a brandCode exists', () => {
     const expectedUserContext: MerchandisingUserContext = {
       category: 'brand123',
-      productId: undefined,
       facets: undefined,
     };
     const routerState: RouterState = {

--- a/projects/cds/src/merchandising/facade/cds-merchandising-user-context.service.spec.ts
+++ b/projects/cds/src/merchandising/facade/cds-merchandising-user-context.service.spec.ts
@@ -102,6 +102,40 @@ describe('CdsMerchandisingUserContextService', () => {
     expect(merchandisingUserContext).toEqual(expectedUserContext);
   });
 
+  it('should return a valid MerchandisingUserContext object, if there are no facets, but a brandCode exists', () => {
+    const expectedUserContext: MerchandisingUserContext = {
+      category: 'brand123',
+      productId: undefined,
+      facets: undefined,
+    };
+    const routerState: RouterState = {
+      navigationId: 1,
+      state: {
+        url: 'electronics-spa/en/USD/',
+        queryParams: {},
+        context: {
+          id: 'homepage',
+        },
+        params: {
+          brandCode: 'brand123',
+        },
+        cmsRequired: true,
+      },
+    };
+
+    spyOn(routingService, 'getRouterState').and.returnValue(of(routerState));
+    spyOn(productSearchService, 'getResults').and.returnValue(
+      of(emptyPageSearchResults)
+    );
+
+    let merchandisingUserContext: MerchandisingUserContext;
+    cdsMerchandisingUserContextService
+      .getUserContext()
+      .subscribe(userContext => (merchandisingUserContext = userContext))
+      .unsubscribe();
+    expect(merchandisingUserContext).toEqual(expectedUserContext);
+  });
+
   it('should return a valid MerchandisingUserContext object, if there are no facets, but a categoryCode exists', () => {
     const expectedUserContext: MerchandisingUserContext = {
       category: '574',

--- a/projects/cds/src/merchandising/facade/cds-merchandising-user-context.service.ts
+++ b/projects/cds/src/merchandising/facade/cds-merchandising-user-context.service.ts
@@ -53,7 +53,9 @@ export class CdsMerchandisingUserContextService {
   private getCategoryNavigationContext(): Observable<string> {
     return this.routingService.getRouterState().pipe(
       map(
-        (routerState: RouterState) => routerState.state.params['categoryCode']
+        (routerState: RouterState) =>
+          routerState.state.params['brandCode'] ||
+          routerState.state.params['categoryCode']
       ),
       distinctUntilChanged()
     );


### PR DESCRIPTION
If a `brandCode` is present, use that as the category when making requests to the strategy service from a merchandising carousel.

This is to work around the fact that when visiting a brand page the `categoryCode` is not populated