### PR TITLE
feat: Support facet topValues in case they have been provided by SOLR

### DIFF
--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.spec.ts
@@ -15,6 +15,34 @@ const mockSource: Occ.ProductSearchPage = {
   products: [{ images: [] }, { images: [] }],
 };
 
+const mockSourceWithFacetTopValues: Occ.ProductSearchPage = {
+  facets: [
+    {
+      values: [
+        { name: '1' },
+        { name: '2' },
+        { name: '3' },
+        { name: '4' },
+        { name: '5' },
+      ],
+      topValues: [{ name: '1' }, { name: '2' }, { name: '3' }],
+    },
+  ],
+};
+const mockSourceWithoutFacetTopValues: Occ.ProductSearchPage = {
+  facets: [
+    {
+      values: [
+        { name: '1' },
+        { name: '2' },
+        { name: '3' },
+        { name: '4' },
+        { name: '5' },
+      ],
+    },
+  ],
+};
+
 describe('OccProductSearchPageNormalizer', () => {
   let normalizer: OccProductSearchPageNormalizer;
 
@@ -46,5 +74,15 @@ describe('OccProductSearchPageNormalizer', () => {
     } as any;
     expect(result).toEqual(expected);
     expect(converter.convert).toHaveBeenCalled();
+  });
+
+  it('should normalize facet topValues', () => {
+    const result = normalizer.convert(mockSourceWithFacetTopValues);
+    expect(result.facets[0].values.length).toEqual(3);
+  });
+
+  it('should not normalize facet topValues', () => {
+    const result = normalizer.convert(mockSourceWithoutFacetTopValues);
+    expect(result.facets[0].values.length).toEqual(5);
   });
 });

--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
@@ -1,11 +1,11 @@
-import { Occ } from '../../../occ-models/occ.models';
+import { Injectable } from '@angular/core';
+import { ProductSearchPage } from '../../../../model/product-search.model';
+import { PRODUCT_NORMALIZER } from '../../../../product/connectors/product/converters';
 import {
   Converter,
   ConverterService,
 } from '../../../../util/converter.service';
-import { Injectable } from '@angular/core';
-import { PRODUCT_NORMALIZER } from '../../../../product/connectors/product/converters';
-import { ProductSearchPage } from '../../../../model/product-search.model';
+import { Occ } from '../../../occ-models/occ.models';
 
 @Injectable({ providedIn: 'root' })
 export class OccProductSearchPageNormalizer
@@ -16,6 +16,7 @@ export class OccProductSearchPageNormalizer
     source: Occ.ProductSearchPage,
     target: ProductSearchPage = {}
   ): ProductSearchPage {
+    this.normalizeFacetValues(source);
     target = {
       ...target,
       ...(source as any),
@@ -25,6 +26,29 @@ export class OccProductSearchPageNormalizer
         this.converterService.convert(product, PRODUCT_NORMALIZER)
       );
     }
+
     return target;
+  }
+
+  /**
+   *
+   * In case there are so-called `topVales` given for the facet values,
+   * we replace the facet values by the topValues, simple because the
+   * values are obsolete.
+   *
+   * `topValues` is a feature in the adaptive search which can limit a large
+   * amount of facet values to a small set (5 by default). As long as the backend
+   * provides all facet values AND topValues, we normalize the data to not bother
+   * the UI with this specific feature.
+   */
+  private normalizeFacetValues(source: Occ.ProductSearchPage) {
+    if (source.facets) {
+      source.facets.map(facet => {
+        if (facet.topValues) {
+          facet.values = facet.topValues;
+          delete facet.topValues;
+        }
+      });
+    }
   }
 }


### PR DESCRIPTION
Adaptive search on the backend provides a mechanism to limit the number of facets to a maximum, using the `defaultTopValuesProvider`. When there are topValues provided, we replace the list of facet values by the topValues in the converter logic. 

closes #5692 