### PR TITLE
fix: Update old cart store only for load/create on active cart

### DIFF
--- a/projects/core/src/cart/store/effects/cart.effect.spec.ts
+++ b/projects/core/src/cart/store/effects/cart.effect.spec.ts
@@ -100,9 +100,6 @@ describe('Cart effect', () => {
         userId: userId,
         cartId: cartId,
       });
-      const loadCartCompletion = new DeprecatedCartActions.LoadCartSuccess(
-        testCart
-      );
       const loadMultiCartCompletion = new CartActions.LoadMultiCartSuccess({
         cart: testCart,
         userId,
@@ -110,9 +107,8 @@ describe('Cart effect', () => {
       });
 
       actions$ = hot('-a', { a: action });
-      const expected = cold('-(bc)', {
-        b: loadCartCompletion,
-        c: loadMultiCartCompletion,
+      const expected = cold('-(b)', {
+        b: loadMultiCartCompletion,
       });
 
       expect(cartEffects.loadCart$).toBeObservable(expected);
@@ -126,9 +122,6 @@ describe('Cart effect', () => {
           addEntries: true,
         },
       });
-      const loadCartCompletion = new DeprecatedCartActions.LoadCartSuccess(
-        testCart
-      );
       const loadMultiCartCompletion = new CartActions.LoadMultiCartSuccess({
         cart: testCart,
         userId,
@@ -138,9 +131,8 @@ describe('Cart effect', () => {
       });
 
       actions$ = hot('-a', { a: action });
-      const expected = cold('-(bc)', {
-        b: loadCartCompletion,
-        c: loadMultiCartCompletion,
+      const expected = cold('-(b)', {
+        b: loadMultiCartCompletion,
       });
 
       expect(cartEffects.loadCart$).toBeObservable(expected);
@@ -219,9 +211,6 @@ describe('Cart effect', () => {
   describe('createCart$', () => {
     it('should create a cart', () => {
       const action = new DeprecatedCartActions.CreateCart({ userId });
-      const createCartSuccessCompletion = new DeprecatedCartActions.CreateCartSuccess(
-        testCart
-      );
       const createMultiCartSuccessCompletion = new CartActions.CreateMultiCartSuccess(
         {
           cart: testCart,
@@ -232,10 +221,40 @@ describe('Cart effect', () => {
       const setFreshCartCompletion = new CartActions.SetFreshCart(testCart);
 
       actions$ = hot('-a', { a: action });
+      const expected = cold('-(bc)', {
+        b: createMultiCartSuccessCompletion,
+        c: setFreshCartCompletion,
+      });
+
+      expect(cartEffects.createCart$).toBeObservable(expected);
+    });
+
+    it('should dispatch CreateCartSuccess action for active cart', () => {
+      const action = new DeprecatedCartActions.CreateCart({
+        userId,
+        extraData: {
+          active: true,
+        },
+      });
+      const createCartSuccessCompletion = new DeprecatedCartActions.CreateCartSuccess(
+        testCart
+      );
+      const createMultiCartSuccessCompletion = new CartActions.CreateMultiCartSuccess(
+        {
+          cart: testCart,
+          userId,
+          extraData: {
+            active: true,
+          },
+        }
+      );
+      const setFreshCartCompletion = new CartActions.SetFreshCart(testCart);
+
+      actions$ = hot('-a', { a: action });
       const expected = cold('-(bcd)', {
-        b: createCartSuccessCompletion,
-        c: createMultiCartSuccessCompletion,
-        d: setFreshCartCompletion,
+        b: createMultiCartSuccessCompletion,
+        c: setFreshCartCompletion,
+        d: createCartSuccessCompletion,
       });
 
       expect(cartEffects.createCart$).toBeObservable(expected);
@@ -247,9 +266,6 @@ describe('Cart effect', () => {
         oldCartId: 'testOldCartId',
       });
 
-      const createCartCompletion = new DeprecatedCartActions.CreateCartSuccess(
-        testCart
-      );
       const createMultiCartCompletion = new CartActions.CreateMultiCartSuccess({
         cart: testCart,
         userId,
@@ -267,12 +283,11 @@ describe('Cart effect', () => {
       });
 
       actions$ = hot('-a', { a: action });
-      const expected = cold('-(bcdef)', {
-        b: createCartCompletion,
-        c: createMultiCartCompletion,
-        d: setFreshCartCompletion,
-        e: mergeCartCompletion,
-        f: mergeMultiCartCompletion,
+      const expected = cold('-(bcde)', {
+        b: createMultiCartCompletion,
+        c: setFreshCartCompletion,
+        d: mergeCartCompletion,
+        e: mergeMultiCartCompletion,
       });
 
       expect(cartEffects.createCart$).toBeObservable(expected);

--- a/projects/core/src/cart/store/effects/cart.effect.ts
+++ b/projects/core/src/cart/store/effects/cart.effect.ts
@@ -23,7 +23,10 @@ import { CartDataService } from '../../facade/cart-data.service';
 import * as DeprecatedCartActions from '../actions/cart.action';
 import { CartActions } from '../actions/index';
 import { StateWithMultiCart } from '../multi-cart-state';
-import { getCartHasPendingProcessesSelectorFactory } from '../selectors/multi-cart.selector';
+import {
+  getActiveCartId,
+  getCartHasPendingProcessesSelectorFactory,
+} from '../selectors/multi-cart.selector';
 
 @Injectable()
 export class CartEffects {
@@ -75,10 +78,26 @@ export class CartEffects {
           return this.cartConnector
             .load(loadCartParams.userId, loadCartParams.cartId)
             .pipe(
-              mergeMap((cart: Cart) => {
+              // TODO: remove with the `cart` store feature
+              withLatestFrom(
+                // TODO: deprecated -> remove check for store in 2.0 when store will be required
+                !this.store
+                  ? of(payload.cartId)
+                  : this.store.pipe(select(getActiveCartId))
+              ),
+              mergeMap(([cart, activeCartId]: [Cart, string]) => {
                 let actions = [];
                 if (cart) {
-                  actions.push(new DeprecatedCartActions.LoadCartSuccess(cart));
+                  // `cart` store branch should only be updated for active cart
+                  // avoid dispatching LoadCartSuccess action on different cart loads
+                  if (
+                    loadCartParams.cartId === activeCartId ||
+                    loadCartParams.cartId === OCC_CART_ID_CURRENT
+                  ) {
+                    actions.push(
+                      new DeprecatedCartActions.LoadCartSuccess(cart)
+                    );
+                  }
                   actions.push(
                     new CartActions.LoadMultiCartSuccess({
                       cart,
@@ -165,15 +184,15 @@ export class CartEffects {
         .create(payload.userId, payload.oldCartId, payload.toMergeCartGuid)
         .pipe(
           switchMap((cart: Cart) => {
-            const mergeActions = [];
+            const conditionalActions = [];
             if (payload.oldCartId) {
-              mergeActions.push(
+              conditionalActions.push(
                 new DeprecatedCartActions.MergeCartSuccess({
                   userId: payload.userId,
                   cartId: cart.code,
                 })
               );
-              mergeActions.push(
+              conditionalActions.push(
                 new CartActions.MergeMultiCartSuccess({
                   userId: payload.userId,
                   cartId: cart.code,
@@ -181,15 +200,21 @@ export class CartEffects {
                 })
               );
             }
+            // `cart` store branch should only be updated for active cart
+            // avoid dispatching CreateCartSuccess action on different cart loads
+            if (payload.extraData && payload.extraData.active) {
+              conditionalActions.push(
+                new DeprecatedCartActions.CreateCartSuccess(cart)
+              );
+            }
             return [
-              new DeprecatedCartActions.CreateCartSuccess(cart),
               new CartActions.CreateMultiCartSuccess({
                 cart,
                 userId: payload.userId,
                 extraData: payload.extraData,
               }),
               new CartActions.SetFreshCart(cart),
-              ...mergeActions,
+              ...conditionalActions,
             ];
           }),
           catchError(error =>


### PR DESCRIPTION
We can't detect if we modify the active cart in `cart.reducer`.
To fix the updates we need to prevent the only 2 actions that can change it's content if we operate on cart different than the active.

Closes #5792 