### PR TITLE
feat: Manipulate cart entries by key

### DIFF
--- a/projects/core/src/cart/facade/active-cart.service.ts
+++ b/projects/core/src/cart/facade/active-cart.service.ts
@@ -310,6 +310,15 @@ export class ActiveCartService {
   }
 
   /**
+   * Remove entry by key
+   *
+   * @param key
+   */
+  removeEntryByKey(key: string): void {
+    this.multiCartService.removeEntryByKey(this.userId, this.cartId, key);
+  }
+
+  /**
    * Update entry
    *
    * @param entryNumber
@@ -325,6 +334,21 @@ export class ActiveCartService {
   }
 
   /**
+   * Update entry by key
+   *
+   * @param key
+   * @param quantity
+   */
+  updateEntryByKey(key: string, quantity: number): void {
+    this.multiCartService.updateEntryByKey(
+      this.userId,
+      this.cartId,
+      key,
+      quantity
+    );
+  }
+
+  /**
    * Returns cart entry
    *
    * @param productCode
@@ -332,6 +356,18 @@ export class ActiveCartService {
   getEntry(productCode: string): Observable<OrderEntry> {
     return this.activeCartId$.pipe(
       switchMap(cartId => this.multiCartService.getEntry(cartId, productCode)),
+      distinctUntilChanged()
+    );
+  }
+
+  /**
+   * Returns cart entry by key
+   *
+   * @param key
+   */
+  getEntryByKey(key: string): Observable<OrderEntry> {
+    return this.activeCartId$.pipe(
+      switchMap(cartId => this.multiCartService.getEntryByKey(cartId, key)),
       distinctUntilChanged()
     );
   }

--- a/projects/core/src/cart/facade/multi-cart.service.ts
+++ b/projects/core/src/cart/facade/multi-cart.service.ts
@@ -180,6 +180,23 @@ export class MultiCartService {
   }
 
   /**
+   * Remove entry from cart
+   *
+   * @param userId
+   * @param cartId
+   * @param key
+   */
+  removeEntryByKey(userId: string, cartId: string, key: string): void {
+    this.store.dispatch(
+      new CartActions.CartRemoveEntryByKey({
+        userId,
+        cartId,
+        key,
+      })
+    );
+  }
+
+  /**
    * Update entry in cart. For quantity = 0 it removes entry
    *
    * @param userId
@@ -208,16 +225,56 @@ export class MultiCartService {
   }
 
   /**
+   * Update entry in cart by key. For quantity 0 it removes entry
+   *
+   * @param userId
+   * @param cartId
+   * @param key
+   * @param quantity
+   */
+  updateEntryByKey(
+    userId: string,
+    cartId: string,
+    key: string,
+    quantity: number
+  ): void {
+    if (quantity > 0) {
+      this.store.dispatch(
+        new CartActions.CartUpdateEntryByKey({
+          userId,
+          cartId,
+          key,
+          quantity,
+        })
+      );
+    } else {
+      this.removeEntryByKey(userId, cartId, key);
+    }
+  }
+
+  /**
    * Get specific entry from cart
    *
    * @param cartId
    * @param productCode
    */
-  getEntry(cartId: string, productCode: string): Observable<OrderEntry | null> {
+  getEntry(cartId: string, productCode: string): Observable<OrderEntry> {
     return this.store.pipe(
       select(
         MultiCartSelectors.getCartEntrySelectorFactory(cartId, productCode)
       )
+    );
+  }
+
+  /**
+   * Get entry from cart by entry key
+   *
+   * @param cartId
+   * @param key
+   */
+  getEntryByKey(cartId: string, key: string): Observable<OrderEntry> {
+    return this.store.pipe(
+      select(MultiCartSelectors.getCartEntryByKeySelectorFactory(cartId, key))
     );
   }
 

--- a/projects/core/src/cart/store/actions/cart-entry.action.ts
+++ b/projects/core/src/cart/store/actions/cart-entry.action.ts
@@ -1,5 +1,10 @@
+import {
+  EntityProcessesDecrementAction,
+  EntityProcessesIncrementAction,
+} from '../../../state/utils/entity-processes-loader/entity-processes-loader.action';
 import { StateLoaderActions } from '../../../state/utils/index';
 import { CART_DATA } from '../cart-state';
+import { MULTI_CART_FEATURE } from '../multi-cart-state';
 
 export const CART_ADD_ENTRY = '[Cart-entry] Add Entry';
 export const CART_ADD_ENTRY_SUCCESS = '[Cart-entry] Add Entry Success';
@@ -8,9 +13,21 @@ export const CART_REMOVE_ENTRY = '[Cart-entry] Remove Entry';
 export const CART_REMOVE_ENTRY_SUCCESS = '[Cart-entry] Remove Entry Success';
 export const CART_REMOVE_ENTRY_FAIL = '[Cart-entry] Remove Entry Fail';
 
+export const CART_REMOVE_ENTRY_BY_KEY = '[Cart-entry] Remove Entry By Key';
+export const CART_REMOVE_ENTRY_BY_KEY_SUCCESS =
+  '[Cart-entry] Remove Entry By Key Success';
+export const CART_REMOVE_ENTRY_BY_KEY_FAIL =
+  '[Cart-entry] Remove Entry By Key Fail';
+
 export const CART_UPDATE_ENTRY = '[Cart-entry] Update Entry';
 export const CART_UPDATE_ENTRY_SUCCESS = '[Cart-entry] Update Entry Success';
 export const CART_UPDATE_ENTRY_FAIL = '[Cart-entry] Update Entry Fail';
+
+export const CART_UPDATE_ENTRY_BY_KEY = '[Cart-entry] Update Entry By Key';
+export const CART_UPDATE_ENTRY_BY_KEY_SUCCESS =
+  '[Cart-entry] Update Entry By Key Success';
+export const CART_UPDATE_ENTRY_BY_KEY_FAIL =
+  '[Cart-entry] Update Entry By Key Fail';
 
 export class CartAddEntry extends StateLoaderActions.LoaderLoadAction {
   readonly type = CART_ADD_ENTRY;
@@ -54,6 +71,29 @@ export class CartRemoveEntryFail extends StateLoaderActions.LoaderFailAction {
   }
 }
 
+export class CartRemoveEntryByKey extends EntityProcessesIncrementAction {
+  readonly type = CART_REMOVE_ENTRY_BY_KEY;
+  constructor(public payload: { cartId: string; userId: string; key: string }) {
+    super(MULTI_CART_FEATURE, payload.cartId);
+  }
+}
+
+export class CartRemoveEntryByKeySuccess extends EntityProcessesDecrementAction {
+  readonly type = CART_REMOVE_ENTRY_BY_KEY_SUCCESS;
+  constructor(public payload: { cartId: string; userId: string; key: string }) {
+    super(MULTI_CART_FEATURE, payload.cartId);
+  }
+}
+
+export class CartRemoveEntryByKeyFail extends EntityProcessesDecrementAction {
+  readonly type = CART_REMOVE_ENTRY_BY_KEY_FAIL;
+  constructor(
+    public payload: { cartId: string; userId: string; key: string; error: any }
+  ) {
+    super(MULTI_CART_FEATURE, payload.cartId);
+  }
+}
+
 export class CartUpdateEntry extends StateLoaderActions.LoaderLoadAction {
   readonly type = CART_UPDATE_ENTRY;
   constructor(public payload: any) {
@@ -75,6 +115,48 @@ export class CartUpdateEntryFail extends StateLoaderActions.LoaderFailAction {
   }
 }
 
+export class CartUpdateEntryByKey extends EntityProcessesIncrementAction {
+  readonly type = CART_UPDATE_ENTRY_BY_KEY;
+  constructor(
+    public payload: {
+      cartId: string;
+      userId: string;
+      key: string;
+      quantity: number;
+    }
+  ) {
+    super(MULTI_CART_FEATURE, payload.cartId);
+  }
+}
+
+export class CartUpdateEntryByKeySuccess extends EntityProcessesDecrementAction {
+  readonly type = CART_UPDATE_ENTRY_BY_KEY_SUCCESS;
+  constructor(
+    public payload: {
+      cartId: string;
+      userId: string;
+      key: string;
+      quantity: number;
+    }
+  ) {
+    super(MULTI_CART_FEATURE, payload.cartId);
+  }
+}
+
+export class CartUpdateEntryByKeyFail extends EntityProcessesDecrementAction {
+  readonly type = CART_UPDATE_ENTRY_BY_KEY_FAIL;
+  constructor(
+    public payload: {
+      cartId: string;
+      userId: string;
+      key: string;
+      quantity: number;
+    }
+  ) {
+    super(MULTI_CART_FEATURE, payload.cartId);
+  }
+}
+
 export type CartEntryAction =
   | CartAddEntry
   | CartAddEntrySuccess
@@ -82,6 +164,12 @@ export type CartEntryAction =
   | CartRemoveEntry
   | CartRemoveEntrySuccess
   | CartRemoveEntryFail
+  | CartRemoveEntryByKey
+  | CartRemoveEntryByKeySuccess
+  | CartRemoveEntryByKeyFail
   | CartUpdateEntry
   | CartUpdateEntrySuccess
-  | CartUpdateEntryFail;
+  | CartUpdateEntryFail
+  | CartUpdateEntryByKey
+  | CartUpdateEntryByKeySuccess
+  | CartUpdateEntryByKeyFail;

--- a/projects/core/src/cart/store/selectors/multi-cart.selector.ts
+++ b/projects/core/src/cart/store/selectors/multi-cart.selector.ts
@@ -97,6 +97,18 @@ export const getCartEntrySelectorFactory = (
   );
 };
 
+export const getCartEntryByKeySelectorFactory = (
+  cartId: string,
+  key: string
+): MemoizedSelector<StateWithMultiCart, OrderEntry> => {
+  return createSelector(
+    getCartEntriesSelectorFactory(cartId),
+    (state: OrderEntry[]) => {
+      return state ? state.find(entry => entry.key === key) : undefined;
+    }
+  );
+};
+
 export const getActiveCartId: MemoizedSelector<
   StateWithMultiCart,
   string

--- a/projects/core/src/model/order.model.ts
+++ b/projects/core/src/model/order.model.ts
@@ -1,5 +1,3 @@
-import { Price, Product } from './product.model';
-import { PaginationModel, SortModel } from './misc.model';
 import { Address } from './address.model';
 import {
   DeliveryOrderEntryGroup,
@@ -8,7 +6,9 @@ import {
   PromotionResult,
   Voucher,
 } from './cart.model';
+import { PaginationModel, SortModel } from './misc.model';
 import { PointOfService } from './point-of-service.model';
+import { Price, Product } from './product.model';
 
 export interface DeliveryMode {
   code?: string;
@@ -22,6 +22,7 @@ export interface OrderEntry {
   deliveryMode?: DeliveryMode;
   deliveryPointOfService?: PointOfService;
   entryNumber?: number;
+  key?: string;
   product?: Product;
   quantity?: number;
   totalPrice?: Price;

--- a/projects/core/src/occ/adapters/cart/converters/occ-cart-normalizer.ts
+++ b/projects/core/src/occ/adapters/cart/converters/occ-cart-normalizer.ts
@@ -17,10 +17,17 @@ export class OccCartNormalizer implements Converter<Occ.Cart, Cart> {
     }
 
     if (source && source.entries) {
-      target.entries = source.entries.map(entry => ({
-        ...entry,
-        product: this.converter.convert(entry.product, PRODUCT_NORMALIZER),
-      }));
+      target.entries = source.entries.map(entry => {
+        const product = this.converter.convert(
+          entry.product,
+          PRODUCT_NORMALIZER
+        );
+        return {
+          ...entry,
+          key: `${product.code}_${entry.basePrice.formattedValue}_${product.name}`,
+          product,
+        };
+      });
     }
 
     this.removeDuplicatePromotions(source, target);


### PR DESCRIPTION
The initial idea about entries modification by key instead of `product code` or `entryNumber`.

In `occ-cart-normalizer` you can see computed `key` property that should be unique in cart entries (in PR this is an example value. I don't have enough knowledge about products to come with something better and truly unique). However, everyone can easily change that implementation with their own `normalizer` (taking into consideration attributes, variants etc.).

More important part of the PR is new API allowing to `getEntryByKey`, `updateEntryByKey` or `removeEntryByKey`. You couldn't use `getEntry` when there were 2 products with the same product code.

`removeEntry` and `updateEntry` are also flawed in the case of multiple operations on cart at the same time. It could remove wrong entry (because in the meantime entryNumber changed) or update wrong product.

To improve that `OCC` behavior 2 new effects are created `removeEntryByKey$` and `updateEntryByKey$`. Before modifying cart there is `load` call to have data as fresh as possible. Then looking in this cart for correct `entryNumber` based on entryKey and then calling `update` or `remove`.

New API is only added in `ActiveCartService` to encourage faster adoption of that service. I would promote using those new methods and drop support for `updateEntry`, `getEntry` and `removeEntry` in the near future.

Closes #5749 
