### PR TITLE
feat: Optimize CMS components data loading

### DIFF
--- a/projects/core/src/cms/facade/cms.service.ts
+++ b/projects/core/src/cms/facade/cms.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
-import { combineLatest, Observable, of } from 'rxjs';
+import { combineLatest, Observable, of, queueScheduler } from 'rxjs';
 import {
   catchError,
+  distinctUntilChanged,
   filter,
+  observeOn,
   pluck,
   shareReplay,
   switchMap,
@@ -75,6 +77,7 @@ export class CmsService {
           select(CmsSelectors.componentStateSelectorFactory(uid))
         ),
       ]).pipe(
+        observeOn(queueScheduler),
         tap(([isNavigating, componentState]) => {
           // componentState is undefined when the whole components entities are empty.
           // In this case, we don't load component one by one, but extract component data from cms page
@@ -91,6 +94,7 @@ export class CmsService {
         pluck(1),
         filter(componentState => componentState && componentState.success),
         pluck('value'),
+        distinctUntilChanged(),
         shareReplay({ bufferSize: 1, refCount: true })
       );
     }

--- a/projects/core/src/cms/store/effects/component.effect.spec.ts
+++ b/projects/core/src/cms/store/effects/component.effect.spec.ts
@@ -27,9 +27,6 @@ class MockRoutingService {
 }
 
 class MockCmsComponentConnector {
-  get(_uid, _pageContext): Observable<any> {
-    return of({});
-  }
   getList(_uid, _pageContext): Observable<any> {
     return of([]);
   }

--- a/projects/core/src/cms/store/effects/component.effect.spec.ts
+++ b/projects/core/src/cms/store/effects/component.effect.spec.ts
@@ -2,7 +2,7 @@ import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { StoreModule } from '@ngrx/store';
-import { cold, hot } from 'jasmine-marbles';
+import { cold, getTestScheduler, hot } from 'jasmine-marbles';
 import { Observable, of } from 'rxjs';
 import { CmsComponent, PageType } from '../../../model/cms.model';
 import { RoutingService } from '../../../routing/index';
@@ -29,6 +29,9 @@ class MockRoutingService {
 class MockCmsComponentConnector {
   get(_uid, _pageContext): Observable<any> {
     return of({});
+  }
+  getList(_uid, _pageContext): Observable<any> {
+    return of([]);
   }
 }
 
@@ -63,23 +66,36 @@ describe('Component Effects', () => {
     it('should return a component from LoadComponentSuccess', () => {
       const action = new CmsActions.LoadCmsComponent('comp1');
       const completion = new CmsActions.LoadCmsComponentSuccess(component);
-      spyOn(service, 'get').and.returnValue(of(component));
+      spyOn(service, 'getList').and.returnValue(of([component]));
 
       actions$ = hot('-a', { a: action });
       const expected = cold('-b', { b: completion });
 
-      expect(effects.loadComponent$).toBeObservable(expected);
+      expect(
+        effects.loadComponent$({ scheduler: getTestScheduler() })
+      ).toBeObservable(expected);
     });
 
-    it('should process only one ongoing request for multiple load component dispatches for the same uid', () => {
-      const action = new CmsActions.LoadCmsComponent('comp1');
-      const completion = new CmsActions.LoadCmsComponentSuccess(component);
-      spyOn(service, 'get').and.returnValue(cold('---c', { c: component }));
+    it('should group component load in specified time frame', () => {
+      const action1 = new CmsActions.LoadCmsComponent('comp1');
+      const action2 = new CmsActions.LoadCmsComponent('comp2');
+      const component2 = { ...component, uid: 'comp2' };
+      const completion1 = new CmsActions.LoadCmsComponentSuccess(component);
+      const completion2 = new CmsActions.LoadCmsComponentSuccess(component2);
+      spyOn(service, 'getList').and.returnValue(
+        cold('---c', { c: [component, component2] })
+      );
 
-      actions$ = hot('-aaa------a', { a: action });
-      const expected = cold('------b------b', { b: completion });
+      actions$ = hot('-ab', { a: action1, b: action2 });
+      const expected = cold('-------(ab)', { a: completion1, b: completion2 });
 
-      expect(effects.loadComponent$).toBeObservable(expected);
+      expect(
+        effects.loadComponent$({ scheduler: getTestScheduler(), debounce: 20 })
+      ).toBeObservable(expected);
+      expect(service.getList).toHaveBeenCalledWith(['comp1', 'comp2'], {
+        id: '1',
+        type: 'ProductPage',
+      });
     });
   });
 });

--- a/projects/core/src/cms/store/effects/component.effect.ts
+++ b/projects/core/src/cms/store/effects/component.effect.ts
@@ -1,20 +1,24 @@
 import { Injectable } from '@angular/core';
-import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Observable, of } from 'rxjs';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { from, Observable } from 'rxjs';
 import {
   catchError,
   filter,
-  groupBy,
   map,
   mergeMap,
   switchMap,
-  take,
+  withLatestFrom,
 } from 'rxjs/operators';
-import { CmsComponent } from '../../../model/cms.model';
-import { RoutingService } from '../../../routing/index';
+import { PageContext, RoutingService } from '../../../routing/index';
 import { makeErrorSerializable } from '../../../util/serialization-utils';
 import { CmsComponentConnector } from '../../connectors/component/cms-component.connector';
 import { CmsActions } from '../actions/index';
+import { bufferDebounceTime } from '../../../util/buffer-debounce-time';
+import { AuthActions } from '../../../auth/store/actions/index';
+import { SiteContextActions } from '../../../site-context/store/actions/index';
+import { withdrawOn } from '../../../util/withdraw-on';
+import { Action } from '@ngrx/store';
+import { CmsComponent } from '../../../model/cms.model';
 
 @Injectable()
 export class ComponentEffects {
@@ -24,37 +28,65 @@ export class ComponentEffects {
     private routingService: RoutingService
   ) {}
 
-  @Effect()
-  loadComponent$: Observable<
+  private currentPageContext$: Observable<
+    PageContext
+  > = this.routingService.getRouterState().pipe(
+    filter(routerState => routerState !== undefined),
+    map(routerState => routerState.state.context)
+  );
+
+  private contextChange$: Observable<Action> = this.actions$.pipe(
+    ofType(
+      SiteContextActions.LANGUAGE_CHANGE,
+      AuthActions.LOGOUT,
+      AuthActions.LOGIN
+    )
+  );
+
+  loadComponent$ = createEffect(
+    () => ({ scheduler, debounce = 0 } = {}): Observable<
+      | CmsActions.LoadCmsComponentSuccess<CmsComponent>
+      | CmsActions.LoadCmsComponentFail
+    > =>
+      this.actions$.pipe(
+        ofType(CmsActions.LOAD_CMS_COMPONENT),
+        map((action: CmsActions.LoadCmsComponent) => action.payload),
+        bufferDebounceTime(debounce, scheduler),
+        withLatestFrom(this.currentPageContext$),
+        mergeMap(([componentUids, pageContext]) =>
+          this.loadComponentsEffect(componentUids, pageContext)
+        ),
+        withdrawOn(this.contextChange$)
+      )
+  );
+
+  private loadComponentsEffect(
+    componentUids: string[],
+    pageContext: PageContext
+  ): Observable<
     | CmsActions.LoadCmsComponentSuccess<CmsComponent>
     | CmsActions.LoadCmsComponentFail
-  > = this.actions$.pipe(
-    ofType(CmsActions.LOAD_CMS_COMPONENT),
-    map((action: CmsActions.LoadCmsComponent) => action.payload),
-    groupBy(uid => uid),
-    mergeMap(group =>
-      group.pipe(
-        switchMap(uid =>
-          this.routingService.getRouterState().pipe(
-            filter(routerState => routerState !== undefined),
-            map(routerState => routerState.state.context),
-            take(1),
-            mergeMap(pageContext =>
-              this.cmsComponentLoader.get(uid, pageContext).pipe(
-                map(data => new CmsActions.LoadCmsComponentSuccess(data, uid)),
-                catchError(error =>
-                  of(
-                    new CmsActions.LoadCmsComponentFail(
-                      uid,
-                      makeErrorSerializable(error)
-                    )
-                  )
-                )
+  > {
+    return this.cmsComponentLoader.getList(componentUids, pageContext).pipe(
+      switchMap(components =>
+        from(
+          components.map(
+            component =>
+              new CmsActions.LoadCmsComponentSuccess(component, component.uid)
+          )
+        )
+      ),
+      catchError(error =>
+        from(
+          componentUids.map(
+            uid =>
+              new CmsActions.LoadCmsComponentFail(
+                uid,
+                makeErrorSerializable(error)
               )
-            )
           )
         )
       )
-    )
-  );
+    );
+  }
 }


### PR DESCRIPTION
Closes #5845

Coalesce multiple calls for a component data into one.

Should make #3769 obsolete, as optimization is done under the hood.