### PR TITLE
fix link to license file from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ Many improvements are coming! All tasks will be posted to our GitHub issue track
 # License
 
 Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
-This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE](LICENSE.txt) file.
+This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE](LICENSE) file.
 


### PR DESCRIPTION
License link had .txt in the link but there is no extension