### PR TITLE
fix: add sanitiser to json-ld script content

### DIFF
--- a/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.spec.ts
@@ -38,6 +38,39 @@ describe('JsonLdScriptFactory', () => {
       const scriptElement = winRef.document.getElementById('json-ld');
       expect(scriptElement.innerHTML).toEqual(`[{"foo":"bar-2"}]`);
     });
+
+    describe('sanitized', () => {
+      it('should sanitize malicious code', () => {
+        service.build([{ foo: 'bar-2<script>alert()</script>' }]);
+        const scriptElement = winRef.document.getElementById('json-ld');
+        expect(scriptElement.innerHTML).toEqual(`[{"foo":"bar-2"}]`);
+      });
+
+      it('should sanitize deep nested malicious code', () => {
+        service.build([
+          {
+            foo: { bar: { deep: 'before <script>alert()</script>and after' } },
+          },
+        ]);
+        const scriptElement = winRef.document.getElementById('json-ld');
+        expect(scriptElement.innerHTML).toEqual(
+          `[{"foo":{"bar":{"deep":"before and after"}}}]`
+        );
+      });
+
+      it('should sanitize everywhere', () => {
+        service.build([
+          {
+            foo: 'clean up <script>alert()</script>please',
+            bar: 'and here <script>alert()</script>as well',
+          },
+        ]);
+        const scriptElement = winRef.document.getElementById('json-ld');
+        expect(scriptElement.innerHTML).toEqual(
+          `[{"foo":"clean up please","bar":"and here as well"}]`
+        );
+      });
+    });
   });
 
   describe('browser', () => {

--- a/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.ts
+++ b/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.ts
@@ -65,7 +65,7 @@ export class JsonLdScriptFactory {
   sanitize(schema: {}): string {
     return JSON.stringify(schema, (_key, value) =>
       typeof value === 'string'
-        ? (value = this.sanitizer.sanitize(SecurityContext.HTML, value))
+        ? this.sanitizer.sanitize(SecurityContext.HTML, value)
         : value
     );
   }

--- a/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.ts
+++ b/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.ts
@@ -6,7 +6,9 @@ import {
   PLATFORM_ID,
   Renderer2,
   RendererFactory2,
+  SecurityContext,
 } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import { WindowRef } from '@spartacus/core';
 
 @Injectable({
@@ -16,12 +18,13 @@ export class JsonLdScriptFactory {
   constructor(
     @Inject(PLATFORM_ID) protected platformId: string,
     protected winRef: WindowRef,
-    protected rendererFactory: RendererFactory2
+    protected rendererFactory: RendererFactory2,
+    protected sanitizer: DomSanitizer
   ) {}
 
   build(schema: {}[]): void {
     if (schema && this.isJsonLdRequired()) {
-      this.createJsonLdScriptElement().innerHTML = JSON.stringify(schema);
+      this.createJsonLdScriptElement().innerHTML = this.sanitize(schema);
     }
   }
 
@@ -51,5 +54,19 @@ export class JsonLdScriptFactory {
       scriptElement = script;
     }
     return scriptElement;
+  }
+
+  /**
+   * Sanitizes the given json-ld schema by leveraging the angular HTML sanitizer.
+   *
+   * The given schema is not trusted, as malicious code could be injected (XSS)
+   * into the json-ld script.
+   */
+  sanitize(schema: {}): string {
+    return JSON.stringify(schema, (_key, value) =>
+      typeof value === 'string'
+        ? (value = this.sanitizer.sanitize(SecurityContext.HTML, value))
+        : value
+    );
   }
 }

--- a/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld.directive.spec.ts
@@ -50,4 +50,14 @@ describe('JsonLdDirective', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML).not.toContain('<script');
   });
+
+  // a single test for sanitization as more tests are created in the json-ld script factort
+  it('should sanitize malicious code', () => {
+    const template = `<span [cxJsonLd]="{foo: 'bar<script>alert(1)</script>'}">hello</span>`;
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toContain(
+      '<script type="application/ld+json">{"foo":"bar"}</script>'
+    );
+  });
 });

--- a/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld.directive.ts
@@ -24,9 +24,8 @@ export class JsonLdDirective {
 
   private writeJsonLd(schema: {}) {
     if (schema && this.jsonLdScriptFactory.isJsonLdRequired()) {
-      const html = `<script type="application/ld+json">${JSON.stringify(
-        schema
-      )}</script>`;
+      const sanitizedSchema = this.jsonLdScriptFactory.sanitize(schema);
+      const html = `<script type="application/ld+json">${sanitizedSchema}</script>`;
       this.jsonLD = this.sanitizer.bypassSecurityTrustHtml(html);
     }
   }


### PR DESCRIPTION
We're leveraging standard angular sanitiser during the creation of json-ld.

closes #5636