### PR TITLE
chore: Catch issues references with `GH-` and `gh-` prefix

### DIFF
--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -126,6 +126,7 @@ export default async function run(
           noteKeywords: [...breakingChangesKeywords, ...deprecationsKeywords],
           revertPattern: /^revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
           revertCorrespondence: [`header`, `hash`],
+          issuePrefixes: ['#', 'GH-', 'gh-'],
         })
       )
       .pipe(


### PR DESCRIPTION
Correctly find mentioned issues in release notes script when they are prefixed with `GH-` or `gh-` and `#` in commit messages. 

Done according to: https://github.com/conventional-changelog-archived-repos/conventional-commits-parser#issueprefixes

QA steps:
- create some file in core library
- commit it with message ending with `Closes GH-123`. Commit must start with `fix` or `feat` prefix to be picked.
- run release-notes script and check if this commit is picked in notes `npm run release-notes:core -- --to core-1.5.0 > core.md`
- this commit should correctly link to issue `123`

Previously only `#` worked.