### PR TITLE
fix: only navigable items used the pointer cursor

### DIFF
--- a/projects/storefrontlib/src/cms-components/navigation/navigation/navigation-ui.component.html
+++ b/projects/storefrontlib/src/cms-components/navigation/navigation/navigation-ui.component.html
@@ -54,7 +54,7 @@
         [target]="node.target"
         class="all"
       >
-        {{ 'navigation.shopAll' | cxTranslate: { navNode: node.title } }}!
+        {{ 'navigation.shopAll' | cxTranslate: { navNode: node.title } }}
       </cx-generic-link>
       <div
         class="childs"

--- a/projects/storefrontstyles/scss/components/content/navigation/_navigation-ui.scss
+++ b/projects/storefrontstyles/scss/components/content/navigation/_navigation-ui.scss
@@ -90,6 +90,11 @@
       &:hover {
         color: var(--cx-color-primary);
       }
+
+      a {
+        display: block;
+        width: 100%;
+      }
     }
 
     @include media-breakpoint-down(md) {
@@ -108,10 +113,6 @@
         justify-content: space-between;
 
         cursor: pointer;
-        a {
-          display: block;
-          width: 100%;
-        }
       }
 
       h5,

--- a/projects/storefrontstyles/scss/components/content/navigation/_navigation-ui.scss
+++ b/projects/storefrontstyles/scss/components/content/navigation/_navigation-ui.scss
@@ -278,6 +278,15 @@
     }
 
     @include media-breakpoint-up(lg) {
+      @if $theme == 'calydon' {
+        .childs[depth='2'] {
+          > nav {
+            &:not(:only-child):not(:last-child) {
+              padding-inline-end: 20px;
+            }
+          }
+        }
+      }
       // Show dropdowns via hover when no nav is focused
       > nav {
         > .wrapper {
@@ -305,10 +314,10 @@
 
       .childs {
         display: flex;
-        // background: white;
-
-        nav:not(:last-child) {
-          padding-right: 20px;
+        @if $theme != 'calydon' {
+          nav:not(:last-child) {
+            padding-right: 20px;
+          }
         }
       }
 

--- a/projects/storefrontstyles/scss/components/content/navigation/_navigation-ui.scss
+++ b/projects/storefrontstyles/scss/components/content/navigation/_navigation-ui.scss
@@ -12,6 +12,9 @@
 }
 
 %nav-wrapper {
+  .wrapper {
+    cursor: default;
+  }
   // create width of wrapper
   .wrapper[attr='1'] {
     width: 200px;


### PR DESCRIPTION
Visual space around navigation links is now part of the link.
This is introduced with `calydon` theme during the 1.x release. 

closes #5928 
closes #5667