### PR TITLE
fix: Clear user orders on language change action (#5919)

### DIFF
--- a/projects/core/src/user/store/effects/user-orders.effect.spec.ts
+++ b/projects/core/src/user/store/effects/user-orders.effect.spec.ts
@@ -6,6 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, of, throwError } from 'rxjs';
 import { OrderHistoryList } from '../../../model/order.model';
+import { SiteContextActions } from '../../../site-context/store/actions/index';
 import { UserOrderAdapter } from '../../connectors/order/user-order.adapter';
 import { UserOrderConnector } from '../../connectors/order/user-order.connector';
 import { UserActions } from '../actions/index';
@@ -73,6 +74,19 @@ describe('User Orders effect', () => {
       const expected = cold('-b', { b: completion });
 
       expect(userOrdersEffect.loadUserOrders$).toBeObservable(expected);
+    });
+  });
+
+  describe('resetUserOrders$', () => {
+    it('should return a reset action', () => {
+      const action = new SiteContextActions.LanguageChange();
+
+      const completion = new UserActions.ClearUserOrders();
+
+      actions$ = hot('-a', { a: action });
+      const expected = cold('-b', { b: completion });
+
+      expect(userOrdersEffect.resetUserOrders$).toBeObservable(expected);
     });
   });
 });

--- a/projects/core/src/user/store/effects/user-orders.effect.ts
+++ b/projects/core/src/user/store/effects/user-orders.effect.ts
@@ -3,6 +3,7 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Observable, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { OrderHistoryList } from '../../../model/order.model';
+import { SiteContextActions } from '../../../site-context/store/actions/index';
 import { makeErrorSerializable } from '../../../util/serialization-utils';
 import { UserOrderConnector } from '../../connectors/order/user-order.connector';
 import { UserActions } from '../actions/index';
@@ -36,6 +37,16 @@ export class UserOrdersEffect {
             of(new UserActions.LoadUserOrdersFail(makeErrorSerializable(error)))
           )
         );
+    })
+  );
+
+  @Effect()
+  resetUserOrders$: Observable<
+    UserActions.ClearUserOrders
+  > = this.actions$.pipe(
+    ofType(SiteContextActions.LANGUAGE_CHANGE),
+    map(() => {
+      return new UserActions.ClearUserOrders();
     })
   );
 }


### PR DESCRIPTION
Closes #5906