### PR TITLE
feat: change the profiletag consent-reference to be available within the CDS module (GH-5941)

### DIFF
--- a/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.spec.ts
+++ b/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.spec.ts
@@ -1,8 +1,6 @@
 import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
-import {
-  HttpClientTestingModule,
-  HttpTestingController,
-} from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { Type } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 import { OccEndpointsService } from '@spartacus/core';
 import { ProfileTagEventService } from '../services/profiletag-event.service';
@@ -41,7 +39,9 @@ describe('consent reference interceptor', () => {
   it('Should modify the x-consent-reference header if there is a consent-reference', inject(
     [HttpClient, HttpTestingController],
     (http: HttpClient, mock: HttpTestingController) => {
-      const injectorMock = TestBed.get(ProfileTagEventService);
+      const injectorMock = TestBed.get(ProfileTagEventService as Type<
+        ProfileTagEventService
+      >);
       injectorMock.consentReference = 'test-123-abc-!@#';
       let response;
       http
@@ -90,7 +90,7 @@ describe('consent reference interceptor', () => {
   it('Should not add the x-consent-reference header if url is not occ', inject(
     [HttpClient, HttpTestingController],
     (http: HttpClient, mock: HttpTestingController) => {
-      const injector = TestBed.get(ProfileTagEventService);
+      const injector = TestBed.get(ProfileTagEventService as Type<ProfileTagEventService>);
       injector.profileTagDebug = true;
       let response;
       http

--- a/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.spec.ts
+++ b/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.spec.ts
@@ -1,5 +1,8 @@
 import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { Type } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 import { OccEndpointsService } from '@spartacus/core';
@@ -90,7 +93,9 @@ describe('consent reference interceptor', () => {
   it('Should not add the x-consent-reference header if url is not occ', inject(
     [HttpClient, HttpTestingController],
     (http: HttpClient, mock: HttpTestingController) => {
-      const injector = TestBed.get(ProfileTagEventService as Type<ProfileTagEventService>);
+      const injector = TestBed.get(ProfileTagEventService as Type<
+        ProfileTagEventService
+      >);
       injector.profileTagDebug = true;
       let response;
       http

--- a/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.spec.ts
+++ b/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.spec.ts
@@ -11,7 +11,7 @@ import { ConsentReferenceInterceptor } from './consent-reference-interceptor';
 
 describe('consent reference interceptor', () => {
   const ProfileTagEventTrackerMock = {
-    get consentReference() {
+    get latestConsentReference() {
       return null;
     },
   };
@@ -45,7 +45,7 @@ describe('consent reference interceptor', () => {
       const injectorMock = TestBed.get(ProfileTagEventService as Type<
         ProfileTagEventService
       >);
-      injectorMock.consentReference = 'test-123-abc-!@#';
+      injectorMock.latestConsentReference = 'test-123-abc-!@#';
       let response;
       http
         .get('/occ/hasHeader', {

--- a/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.ts
+++ b/projects/cds/src/profiletag/http-interceptors/consent-reference-interceptor.ts
@@ -20,14 +20,14 @@ export class ConsentReferenceInterceptor implements HttpInterceptor {
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
     if (
-      !this.profileTagEventTracker.consentReference ||
+      !this.profileTagEventTracker.latestConsentReference ||
       !this.isOccUrl(request.url)
     ) {
       return next.handle(request);
     }
     const cdsHeaders = request.headers.set(
       'X-Consent-Reference',
-      this.profileTagEventTracker.consentReference
+      this.profileTagEventTracker.latestConsentReference
     );
     const cdsRequest = request.clone({ headers: cdsHeaders });
     return next.handle(cdsRequest);

--- a/projects/cds/src/profiletag/http-interceptors/debug-interceptor.spec.ts
+++ b/projects/cds/src/profiletag/http-interceptors/debug-interceptor.spec.ts
@@ -3,6 +3,7 @@ import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
+import { Type } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 import { OccEndpointsService } from '@spartacus/core';
 import { ProfileTagEventService } from '../services/profiletag-event.service';
@@ -65,7 +66,9 @@ describe('Debug interceptor', () => {
   it('Should modify the x-profile-tag-debug header if the value is true', inject(
     [HttpClient, HttpTestingController],
     (http: HttpClient, mock: HttpTestingController) => {
-      const injector = TestBed.get(ProfileTagEventService);
+      const injector = TestBed.get(ProfileTagEventService as Type<
+        ProfileTagEventService
+      >);
       injector.profileTagDebug = true;
       let response;
       http
@@ -91,7 +94,9 @@ describe('Debug interceptor', () => {
   it('Should not add the x-profile-tag-debug header if url is not occ', inject(
     [HttpClient, HttpTestingController],
     (http: HttpClient, mock: HttpTestingController) => {
-      const injector = TestBed.get(ProfileTagEventService);
+      const injector = TestBed.get(ProfileTagEventService as Type<
+        ProfileTagEventService
+      >);
       injector.profileTagDebug = true;
       let response;
       http

--- a/projects/cds/src/profiletag/services/profiletag-event.service.spec.ts
+++ b/projects/cds/src/profiletag/services/profiletag-event.service.spec.ts
@@ -184,9 +184,9 @@ describe('ProfileTagEventTracker', () => {
     let cr1 = null;
     let cr2 = null;
     let cr3 = null;
-    const subscription1CR = profileTagEventTracker.consentReference$.subscribe(
-      cr => (cr1 = cr)
-    );
+    const subscription1CR = profileTagEventTracker
+      .getConsentReference()
+      .subscribe(cr => (cr1 = cr));
     const consentReferenceChangedEvent = <ConsentReferenceEvent>(
       new CustomEvent(ProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
         detail: { consentReference: 'some_id' },
@@ -195,12 +195,12 @@ describe('ProfileTagEventTracker', () => {
     eventListener[ProfileTagEventNames.CONSENT_REFERENCE_LOADED](
       consentReferenceChangedEvent
     );
-    const subscription2CR = profileTagEventTracker.consentReference$.subscribe(
-      cr => (cr2 = cr)
-    );
-    const subscription3CR = profileTagEventTracker.consentReference$.subscribe(
-      cr => (cr3 = cr)
-    );
+    const subscription2CR = profileTagEventTracker
+      .getConsentReference()
+      .subscribe(cr => (cr2 = cr));
+    const subscription3CR = profileTagEventTracker
+      .getConsentReference()
+      .subscribe(cr => (cr3 = cr));
     subscription1CR.unsubscribe();
     subscription2CR.unsubscribe();
     subscription3CR.unsubscribe();

--- a/projects/cds/src/profiletag/services/profiletag-event.service.spec.ts
+++ b/projects/cds/src/profiletag/services/profiletag-event.service.spec.ts
@@ -1,4 +1,4 @@
-import { PLATFORM_ID } from '@angular/core';
+import { PLATFORM_ID, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { BaseSiteService, WindowRef } from '@spartacus/core';
 import { BehaviorSubject } from 'rxjs';
@@ -75,7 +75,9 @@ describe('ProfileTagEventTracker', () => {
         { provide: PLATFORM_ID, useValue: 'browser' },
       ],
     });
-    profileTagEventTracker = TestBed.get(ProfileTagEventService);
+    profileTagEventTracker = TestBed.get(ProfileTagEventService as Type<
+      ProfileTagEventService
+    >);
     nativeWindow = TestBed.get(WindowRef).nativeWindow;
   });
 
@@ -177,5 +179,33 @@ describe('ProfileTagEventTracker', () => {
     subscription.unsubscribe();
 
     expect(timesCalled).toEqual(2);
+  });
+  it('Should give the lastest consent reference to late subscribers', () => {
+    let cr1 = null;
+    let cr2 = null;
+    let cr3 = null;
+    const subscription1CR = profileTagEventTracker.consentReference$.subscribe(
+      cr => (cr1 = cr)
+    );
+    const consentReferenceChangedEvent = <ConsentReferenceEvent>(
+      new CustomEvent(ProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
+        detail: { consentReference: 'some_id' },
+      })
+    );
+    eventListener[ProfileTagEventNames.CONSENT_REFERENCE_LOADED](
+      consentReferenceChangedEvent
+    );
+    const subscription2CR = profileTagEventTracker.consentReference$.subscribe(
+      cr => (cr2 = cr)
+    );
+    const subscription3CR = profileTagEventTracker.consentReference$.subscribe(
+      cr => (cr3 = cr)
+    );
+    subscription1CR.unsubscribe();
+    subscription2CR.unsubscribe();
+    subscription3CR.unsubscribe();
+    expect(cr1).toEqual(cr2);
+    expect(cr3).toEqual(cr2);
+    expect(cr1).toEqual('some_id');
   });
 });

--- a/projects/cds/src/profiletag/services/profiletag-event.service.ts
+++ b/projects/cds/src/profiletag/services/profiletag-event.service.ts
@@ -25,16 +25,9 @@ import {
   providedIn: 'root',
 })
 export class ProfileTagEventService {
-  public consentReference = null;
-  public profileTagDebug = false;
-  public consentReference$: Observable<string> = fromEvent(
-    this.winRef.nativeWindow,
-    ProfileTagEventNames.CONSENT_REFERENCE_LOADED
-  ).pipe(
-    map(event => <ConsentReferenceEvent>event),
-    map(event => event.detail.consentReference),
-    shareReplay(1)
-  );
+  consentReference = null;
+  profileTagDebug = false;
+  private consentReference$: Observable<string>;
   private profileTagWindow: ProfileTagWindowObject;
   private profileTagEvents$ = merge(
     this.setConsentReference(),
@@ -50,6 +43,20 @@ export class ProfileTagEventService {
   getProfileTagEvents(): Observable<string | DebugEvent | Event> {
     return this.profileTagEvents$;
   }
+  getConsentReference(): Observable<string> {
+    if (this.consentReference$) {
+      return this.consentReference$;
+    }
+    this.consentReference$ = fromEvent(
+      this.winRef.nativeWindow,
+      ProfileTagEventNames.CONSENT_REFERENCE_LOADED
+    ).pipe(
+      map(event => <ConsentReferenceEvent>event),
+      map(event => event.detail.consentReference),
+      shareReplay(1)
+    );
+    return this.consentReference$;
+  }
 
   addTracker(): Observable<Event> {
     return this.baseSiteService.getActive().pipe(
@@ -64,7 +71,7 @@ export class ProfileTagEventService {
   }
 
   private setConsentReference(): Observable<string> {
-    return this.consentReference$.pipe(
+    return this.getConsentReference().pipe(
       tap(consentReference => (this.consentReference = consentReference))
     );
   }

--- a/projects/cds/src/profiletag/services/profiletag-event.service.ts
+++ b/projects/cds/src/profiletag/services/profiletag-event.service.ts
@@ -44,17 +44,16 @@ export class ProfileTagEventService {
     return this.profileTagEvents$;
   }
   getConsentReference(): Observable<string> {
-    if (this.consentReference$) {
-      return this.consentReference$;
+    if (!this.consentReference$) {
+      this.consentReference$ = fromEvent(
+        this.winRef.nativeWindow,
+        ProfileTagEventNames.CONSENT_REFERENCE_LOADED
+      ).pipe(
+        map(event => <ConsentReferenceEvent>event),
+        map(event => event.detail.consentReference),
+        shareReplay(1)
+      );
     }
-    this.consentReference$ = fromEvent(
-      this.winRef.nativeWindow,
-      ProfileTagEventNames.CONSENT_REFERENCE_LOADED
-    ).pipe(
-      map(event => <ConsentReferenceEvent>event),
-      map(event => event.detail.consentReference),
-      shareReplay(1)
-    );
     return this.consentReference$;
   }
 

--- a/projects/cds/src/profiletag/services/profiletag-event.service.ts
+++ b/projects/cds/src/profiletag/services/profiletag-event.service.ts
@@ -25,7 +25,6 @@ import {
   providedIn: 'root',
 })
 export class ProfileTagEventService {
-  private profileTagWindow: ProfileTagWindowObject;
   public consentReference = null;
   public profileTagDebug = false;
   public consentReference$: Observable<string> = fromEvent(
@@ -36,6 +35,7 @@ export class ProfileTagEventService {
     map(event => event.detail.consentReference),
     shareReplay(1)
   );
+  private profileTagWindow: ProfileTagWindowObject;
   private profileTagEvents$ = merge(
     this.setConsentReference(),
     this.debugModeChanged()

--- a/projects/cds/src/profiletag/services/profiletag-event.service.ts
+++ b/projects/cds/src/profiletag/services/profiletag-event.service.ts
@@ -25,7 +25,7 @@ import {
   providedIn: 'root',
 })
 export class ProfileTagEventService {
-  consentReference = null;
+  latestConsentReference = null;
   profileTagDebug = false;
   private consentReference$: Observable<string>;
   private profileTagWindow: ProfileTagWindowObject;
@@ -72,7 +72,7 @@ export class ProfileTagEventService {
 
   private setConsentReference(): Observable<string> {
     return this.getConsentReference().pipe(
-      tap(consentReference => (this.consentReference = consentReference))
+      tap(consentReference => (this.latestConsentReference = consentReference))
     );
   }
 


### PR DESCRIPTION
Publicly exposes the consent-reference within the CDS module via a singleton method, allowing late subscribers to get the last issued consent-reference.

Closes GH-5941