### PR TITLE
fix: PdP qty should be reset to 1 if qty removed and clicked outside (GH-3150)

### DIFF
--- a/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.html
+++ b/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.html
@@ -29,7 +29,7 @@
       [formControl]="inputValue"
       [value]="value"
       *ngIf="isValueChangeable"
-      (blur)="onInputBlur()"
+      (blur)="validateValueOrDefault()"
     />
     <div class="cx-counter-value" *ngIf="!isValueChangeable">
       {{ value }}

--- a/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.html
+++ b/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.html
@@ -29,6 +29,7 @@
       [formControl]="inputValue"
       [value]="value"
       *ngIf="isValueChangeable"
+      (blur)="onInputBlur()"
     />
     <div class="cx-counter-value" *ngIf="!isValueChangeable">
       {{ value }}

--- a/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.spec.ts
+++ b/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.spec.ts
@@ -356,7 +356,7 @@ describe('ItemCounterComponent', () => {
     itemCounterComponent.manualChange(null);
     itemCounterComponent.invalidInput = true;
 
-    itemCounterComponent.onInputBlur();
+    itemCounterComponent.validateValueOrDefault();
     expect(itemCounterComponent.min).toBe(mockMinimum);
   });
 });

--- a/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.spec.ts
+++ b/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.spec.ts
@@ -348,4 +348,15 @@ describe('ItemCounterComponent', () => {
     expect(itemCounterComponent.decrementBtn).toBeUndefined();
     expect(itemCounterComponent.incrementBtn).toBeUndefined();
   });
+
+  it('should reset counter value to the minimum value on cx-item-counter input blur', () => {
+    const mockMinimum = 1;
+    itemCounterComponent.min = mockMinimum;
+
+    itemCounterComponent.manualChange(null);
+    itemCounterComponent.invalidInput = true;
+
+    itemCounterComponent.onInputBlur();
+    expect(itemCounterComponent.min).toBe(mockMinimum);
+  });
 });

--- a/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.ts
+++ b/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.ts
@@ -218,7 +218,7 @@ export class ItemCounterComponent
     return this.value >= this.max || this.value <= this.min;
   }
 
-  onInputBlur() {
+  onInputBlur(): void {
     if (this.invalidInput) {
       this.manualChange(this.min);
     }

--- a/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.ts
+++ b/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.ts
@@ -105,8 +105,7 @@ export class ItemCounterComponent
    * If value is too small it will be set to min, if is too big it will be set to max.
    */
   adjustValueInRange(incomingValue: number): number {
-    // (GH-3150) Covers case where some items have no max value (e.g. Product #816780 on dev-10)
-    if (this.max === null) return this.min;
+    if (this.max === null || this.max === undefined) return this.min;
 
     return this.min !== undefined && incomingValue < this.min
       ? this.min
@@ -218,7 +217,7 @@ export class ItemCounterComponent
     return this.value >= this.max || this.value <= this.min;
   }
 
-  onInputBlur(): void {
+  validateValueOrDefault(): void {
     if (this.invalidInput) {
       this.manualChange(this.min);
     }

--- a/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.ts
+++ b/projects/storefrontlib/src/shared/components/item-counter/item-counter.component.ts
@@ -67,6 +67,8 @@ export class ItemCounterComponent
 
   subscription: Subscription;
 
+  invalidInput: boolean;
+
   ngOnInit() {
     this.writeValue(this.min || 0);
     this.subscription = this.inputValue.valueChanges
@@ -74,6 +76,8 @@ export class ItemCounterComponent
       .subscribe(value => {
         if (value) {
           this.manualChange(Number(value));
+        } else {
+          this.invalidInput = true;
         }
       });
   }
@@ -101,6 +105,9 @@ export class ItemCounterComponent
    * If value is too small it will be set to min, if is too big it will be set to max.
    */
   adjustValueInRange(incomingValue: number): number {
+    // (GH-3150) Covers case where some items have no max value (e.g. Product #816780 on dev-10)
+    if (this.max === null) return this.min;
+
     return this.min !== undefined && incomingValue < this.min
       ? this.min
       : this.max !== undefined && incomingValue > this.max
@@ -209,6 +216,13 @@ export class ItemCounterComponent
 
   isMaxOrMinValueOrBeyond(): boolean {
     return this.value >= this.max || this.value <= this.min;
+  }
+
+  onInputBlur() {
+    if (this.invalidInput) {
+      this.manualChange(this.min);
+    }
+    this.invalidInput = false;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Closes GH-3150