### PR TITLE
fix: XMLHttpRequest error when dynamically loading translations using SSR (for 1.4.x)

### DIFF
--- a/projects/core/src/i18n/config/i18n-config.ts
+++ b/projects/core/src/i18n/config/i18n-config.ts
@@ -2,13 +2,48 @@ import { TranslationResources } from '../translation-resources';
 
 export abstract class I18nConfig {
   i18n?: {
+    /**
+     * When there are missing translation resources for the active language, the fallback language will be used.
+     */
     fallbackLang?: string | false;
+
+    /**
+     * Configuration for lazy loading of translation files.
+     * For eager loading of translations please use config option `i18n.resources`
+     */
+
     backend?: {
+      /**
+       * The path to JSON translations. It should contain placeholders:
+       * - `{{lng}}` for language
+       * - `{{ns}}` for the name of chunk.
+       *
+       * Example:
+       * `assets/i18n-assets/{{lng}}/{{ns}}.json`
+       */
+
       loadPath?: string;
+
+      /**
+       * @deprecated since 1.4 - this property can be removed since it's not used and we are using Angular HttpClient for loading JSON translations
+       */
       crossDomain?: boolean;
     };
+
+    /**
+     * Reference to translation resources that are eagerly bundled with JS app.
+     * For lazy loading of translations please use config option `i18n.backend` instead.
+     */
     resources?: TranslationResources;
+
+    /**
+     * Logs i18n events (like loading translation resources) to the console. Don't use in production!
+     */
     debug?: boolean;
+
+    /**
+     * Mapping that assigns keys' namespaces to specific chunks. The main purpose of chunks is to lazy load them.
+     */
     chunks?: {
       [chunk: string]: string[];
     };

--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -1,0 +1,47 @@
+import { HttpClient } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+  TestRequest,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { i18nextGetHttpClient } from './i18next-init';
+
+describe('i18nextGetHttpClient should return a http client that', () => {
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+  let req: TestRequest;
+  let testCallback: Function;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+
+    httpMock = TestBed.get(HttpTestingController);
+    httpClient = TestBed.get(HttpClient);
+
+    const func = i18nextGetHttpClient(httpClient);
+    testCallback = jasmine.createSpy('testCallback');
+    func('testUrl', null, testCallback, null);
+    req = httpMock.expectOne({ url: 'testUrl', method: 'GET' });
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('requests for responseType text', () => {
+    expect(req.request.responseType).toBe('text');
+  });
+
+  it('forwards success response to i18next callback', () => {
+    req.flush('testResponse');
+    expect(testCallback).toHaveBeenCalledWith('testResponse', { status: 200 });
+  });
+
+  it('forwards failure response to i18next callback', () => {
+    req.flush('test error message', { status: 404, statusText: 'Not Found' });
+    expect(testCallback).toHaveBeenCalledWith(null, { status: 404 });
+  });
+});

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import i18next from 'i18next';
 import i18nextXhrBackend from 'i18next-xhr-backend';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
@@ -6,7 +7,8 @@ import { TranslationResources } from '../translation-resources';
 
 export function i18nextInit(
   configInit: ConfigInitializerService,
-  languageService: LanguageService
+  languageService: LanguageService,
+  httpClient: HttpClient
 ): () => Promise<any> {
   return () =>
     configInit.getStableConfig('i18n').then(config => {
@@ -20,7 +22,11 @@ export function i18nextInit(
       };
       if (config.i18n.backend) {
         i18next.use(i18nextXhrBackend);
-        i18nextConfig = { ...i18nextConfig, backend: config.i18n.backend };
+        const backend = {
+          loadPath: config.i18n.backend.loadPath || undefined,
+          ajax: i18nextGetHttpClient(httpClient),
+        };
+        i18nextConfig = { ...i18nextConfig, backend };
       }
 
       return i18next.init(i18nextConfig, () => {
@@ -49,4 +55,24 @@ export function i18nextAddTranslations(resources: TranslationResources = {}) {
 export function syncI18nextWithSiteContext(language: LanguageService) {
   // always update language of i18next on site context (language) change
   language.getActive().subscribe(lang => i18next.changeLanguage(lang));
+}
+
+/**
+ * Returns a function appropriate for i18next to make http calls for JSON files.
+ * See docs for `i18next-xhr-backend`: https://github.com/i18next/i18next-xhr-backend#backend-options
+ *
+ * It uses Angular HttpClient under the hood, so it works in SSR.
+ * @param httpClient Angular http client
+ */
+export function i18nextGetHttpClient(
+  httpClient: HttpClient
+): (url: string, options: object, callback: Function, data: object) => void {
+  return (url: string, _options: object, callback: Function, _data: object) => {
+    httpClient
+      .get(url, { responseType: 'text' })
+      .subscribe(
+        data => callback(data, { status: 200 }),
+        error => callback(null, { status: error.status })
+      );
+  };
 }

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { APP_INITIALIZER, Provider } from '@angular/core';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
@@ -7,7 +8,7 @@ export const i18nextProviders: Provider[] = [
   {
     provide: APP_INITIALIZER,
     useFactory: i18nextInit,
-    deps: [ConfigInitializerService, LanguageService],
+    deps: [ConfigInitializerService, LanguageService, HttpClient],
     multi: true,
   },
 ];


### PR DESCRIPTION
The `i18next-xhr-plugin` uses XHR to load translation files by default, which doesn't work in SSR. Now it's fixed by defining the function backend.ajax of i18next that uses Angular HttpClient under the hood, so it works in SSR.
Deprecated the Spartacus config option i18n.backend.crossDomain since it's not used anymore.
closes GH-6030