### PR TITLE
fix: avoid loading product classifications twice when feature level <1.4

### DIFF
--- a/projects/core/src/product/services/product-page-meta.resolver.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.ts
@@ -10,12 +10,12 @@ import {
   PageImageResolver,
   PageTitleResolver,
 } from '../../cms/page/page.resolvers';
+import { FeatureConfigService } from '../../features-config/services/feature-config.service';
 import { TranslationService } from '../../i18n/translation.service';
 import { PageType } from '../../model/cms.model';
 import { Product } from '../../model/product.model';
 import { RoutingService } from '../../routing/facade/routing.service';
 import { ProductService } from '../facade/product.service';
-import { FeatureConfigService } from '../../features-config/services/feature-config.service';
 import { ProductScope } from '../model/product-scope';
 
 /**
@@ -44,6 +44,23 @@ export class ProductPageMetaResolver extends PageMetaResolver
     filter(code => !!code),
     switchMap(code => this.productService.get(code, this.PRODUCT_SCOPE)),
     filter(Boolean)
+  );
+
+  constructor(
+    routingService: RoutingService,
+    productService: ProductService,
+    translation: TranslationService,
+    // tslint:disable-next-line: unified-signatures
+    features: FeatureConfigService
+  );
+
+  /**
+   * @deprecated since 1.4
+   */
+  constructor(
+    routingService: RoutingService,
+    productService: ProductService,
+    translation: TranslationService
   );
 
   constructor(

--- a/projects/storefrontlib/src/cms-components/product/carousel/product-carousel/product-carousel.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/carousel/product-carousel/product-carousel.component.ts
@@ -43,6 +43,21 @@ export class ProductCarouselComponent {
   );
 
   constructor(
+    componentData: CmsComponentData<model>,
+    productService: ProductService,
+    // tslint:disable-next-line: unified-signatures
+    features?: FeatureConfigService
+  );
+
+  /**
+   * @deprecated since 1.4
+   */
+  constructor(
+    componentData: CmsComponentData<model>,
+    productService: ProductService
+  );
+
+  constructor(
     protected componentData: CmsComponentData<model>,
     protected productService: ProductService,
     protected features?: FeatureConfigService

--- a/projects/storefrontlib/src/cms-components/product/current-product.service.ts
+++ b/projects/storefrontlib/src/cms-components/product/current-product.service.ts
@@ -43,7 +43,11 @@ export class CurrentProductService {
       switchMap((productCode: string) =>
         this.productService.get(
           productCode,
-          scopes || this.DEFAULT_PRODUCT_SCOPE
+          // TODO deprecated since 1.4 - should be replaced with 'scopes || this.DEFAULT_PRODUCT_SCOPE'
+          this.features && this.features.isLevel('1.4')
+            ? scopes || this.DEFAULT_PRODUCT_SCOPE
+            : undefined
+          // deprecated END
         )
       )
     );

--- a/projects/storefrontlib/src/cms-components/product/current-product.service.ts
+++ b/projects/storefrontlib/src/cms-components/product/current-product.service.ts
@@ -14,6 +14,18 @@ import { filter, map, switchMap } from 'rxjs/operators';
 })
 export class CurrentProductService {
   constructor(
+    routingService: RoutingService,
+    productService: ProductService,
+    // tslint:disable-next-line: unified-signatures
+    features?: FeatureConfigService
+  );
+
+  /**
+   * @deprecated since 1.4
+   */
+  constructor(routingService: RoutingService, productService: ProductService);
+
+  constructor(
     private routingService: RoutingService,
     private productService: ProductService,
     protected features?: FeatureConfigService

--- a/projects/storefrontlib/src/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { FeatureConfigService, Product, ProductScope } from '@spartacus/core';
+import { Product, ProductScope } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { CurrentProductService } from '../../current-product.service';
 
@@ -13,10 +13,7 @@ export class ProductAttributesComponent implements OnInit {
     ProductScope.ATTRIBUTES
   );
 
-  constructor(
-    protected currentProductService: CurrentProductService,
-    protected features?: FeatureConfigService
-  ) {}
+  constructor(protected currentProductService: CurrentProductService) {}
 
   // TODO deprecated since 1.4, remove
   ngOnInit() {}

--- a/projects/storefrontlib/src/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { Product, ProductScope } from '@spartacus/core';
+import { FeatureConfigService, Product, ProductScope } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { CurrentProductService } from '../../current-product.service';
 
@@ -9,11 +9,30 @@ import { CurrentProductService } from '../../current-product.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProductAttributesComponent implements OnInit {
+  protected readonly PRODUCT_SCOPE =
+    this.features && this.features.isLevel('1.4')
+      ? ProductScope.ATTRIBUTES
+      : '';
+
   product$: Observable<Product> = this.currentProductService.getProduct(
-    ProductScope.ATTRIBUTES
+    this.PRODUCT_SCOPE
   );
 
-  constructor(protected currentProductService: CurrentProductService) {}
+  constructor(
+    currentProductService: CurrentProductService,
+    // tslint:disable-next-line: unified-signatures
+    features: FeatureConfigService
+  );
+
+  /**
+   * @deprecated since 1.4
+   */
+  constructor(currentProductService: CurrentProductService);
+
+  constructor(
+    protected currentProductService: CurrentProductService,
+    protected features?: FeatureConfigService
+  ) {}
 
   // TODO deprecated since 1.4, remove
   ngOnInit() {}

--- a/projects/storefrontlib/src/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
@@ -9,25 +9,9 @@ import { CurrentProductService } from '../../current-product.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProductAttributesComponent implements OnInit {
-  protected readonly PRODUCT_SCOPE =
-    this.features && this.features.isLevel('1.4')
-      ? ProductScope.ATTRIBUTES
-      : '';
-
   product$: Observable<Product> = this.currentProductService.getProduct(
-    this.PRODUCT_SCOPE
+    ProductScope.ATTRIBUTES
   );
-
-  constructor(
-    currentProductService: CurrentProductService,
-    // tslint:disable-next-line: unified-signatures
-    features: FeatureConfigService
-  );
-
-  /**
-   * @deprecated since 1.4
-   */
-  constructor(currentProductService: CurrentProductService);
 
   constructor(
     protected currentProductService: CurrentProductService,


### PR DESCRIPTION
1. Use `ProductScopes.ATTRIBUTES` in `ProductAttributesComponent` only when the feature level `1.4` (done inside the logic of the `CurrentProductService`).
2. Deprecated a few constructors which used optional argument - features config service

close GH-6167