### PR TITLE
GH-6218: Re-enable tests that depend on the order history.

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/asm.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/asm.ts
@@ -64,9 +64,7 @@ export function asmTests(isMobile: boolean) {
     });
 
     describe('Customer Emulation - My Account', () => {
-      // Test disabled until a new order can appear quickly enough in the order history
-      // to make this test possible.
-      xit('agent should be able to check order in order history', () => {
+      it('agent should be able to check order in order history', () => {
         checkout.viewOrderHistoryWithCheapProduct();
       });
 
@@ -151,9 +149,7 @@ export function asmTests(isMobile: boolean) {
         loginCustomerInStorefront();
         assertCustomerIsSignedIn(isMobile);
       });
-      // Test disabled until a new order can appear quickly enough in the order history
-      // to make this test possible.
-      xit('customer should see the order placed by the agent.', () => {
+      it('customer should see the order placed by the agent.', () => {
         checkout.viewOrderHistoryWithCheapProduct();
       });
 

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/mobile/checkout/checkout-flow-mobile.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/mobile/checkout/checkout-flow-mobile.e2e-spec.ts
@@ -58,9 +58,7 @@ context(`${formats.mobile.width + 1}p resolution - Big happy path`, () => {
     checkout.verifyOrderConfirmationPageWithCheapProduct();
   });
 
-  // Test disabled until a new order can appear quickly enough in the order history
-  // to make this test possible.
-  xit('should be able to check order in order history', () => {
+  it('should be able to check order in order history', () => {
     clickHamburger();
     checkout.viewOrderHistoryWithCheapProduct();
     clickHamburger();

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/mobile/my-account/order-history-orders-flow-mobile.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/mobile/my-account/order-history-orders-flow-mobile.e2e-spec.ts
@@ -2,7 +2,7 @@ import { doPlaceOrder, orderHistoryTest } from '../../../helpers/order-history';
 import { product } from '../../../sample-data/checkout-flow';
 import { formats } from '../../../sample-data/viewports';
 
-describe.skip(`${formats.mobile.width +
+describe(`${formats.mobile.width +
   1}p resolution - Order History with orders`, () => {
   before(() => {
     cy.window().then(win => win.sessionStorage.clear());
@@ -23,8 +23,7 @@ describe.skip(`${formats.mobile.width +
   orderHistoryTest.checkCorrectDateFormat(true);
 });
 
-describe.skip(`${formats.mobile.width +
-  1}p resolution - Order details page`, () => {
+describe(`${formats.mobile.width + 1}p resolution - Order details page`, () => {
   before(() => {
     cy.window().then(win => win.sessionStorage.clear());
     cy.requireLoggedIn();

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/checkout/checkout-as-guest.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/checkout/checkout-as-guest.e2e-spec.ts
@@ -59,9 +59,7 @@ context('Checkout as guest', () => {
   });
 
   describe('Guest account', () => {
-    // Test disabled until a new order can appear quickly enough in the order history
-    // to make this test possible.
-    xit('should be able to check order in order history', () => {
+    it('should be able to check order in order history', () => {
       checkout.viewOrderHistoryWithCheapProduct();
     });
 

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/my-account/order-history-orders-flow.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/my-account/order-history-orders-flow.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { doPlaceOrder, orderHistoryTest } from '../../../helpers/order-history';
 import { product } from '../../../sample-data/checkout-flow';
 
-describe.skip('Order History with orders', () => {
+describe('Order History with orders', () => {
   before(() => {
     cy.window().then(win => win.sessionStorage.clear());
     cy.requireLoggedIn();
@@ -20,7 +20,7 @@ describe.skip('Order History with orders', () => {
   orderHistoryTest.checkCorrectDateFormat();
 });
 
-describe.skip('Order details page', () => {
+describe('Order details page', () => {
   before(() => {
     cy.requireLoggedIn();
   });

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/site-context/language/language-my-account-pages.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/site-context/language/language-my-account-pages.e2e-spec.ts
@@ -32,6 +32,7 @@ describe('Language switch - my-account pages', () => {
       );
     });
 
+    // TODO: once we get a working order in oms instantly
     xit('should change language in the page', () => {
       siteContextSelector.siteContextChange(
         orderPath,

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/site-context/language/language-my-account-pages.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/site-context/language/language-my-account-pages.e2e-spec.ts
@@ -32,7 +32,6 @@ describe('Language switch - my-account pages', () => {
       );
     });
 
-    // TODO: once we get a working order in oms instantly
     xit('should change language in the page', () => {
       siteContextSelector.siteContextChange(
         orderPath,

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/smoke/checkout-flow.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/smoke/checkout-flow.e2e-spec.ts
@@ -38,9 +38,7 @@ context('Checkout flow', () => {
     checkout.verifyOrderConfirmationPageWithCheapProduct();
   });
 
-  // Test disabled until a new order can appear quickly enough in the order history
-  // to make this test possible.
-  xit('should be able to check order in order history', () => {
+  it('should be able to check order in order history', () => {
     checkout.viewOrderHistoryWithCheapProduct();
     checkout.signOut();
   });


### PR DESCRIPTION
Closes GH-6218