### PR TITLE
fix: loading translations from local JSON files when using SSR

### DIFF
--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -49,13 +49,12 @@ describe('i18nextGetHttpClient should return a http client that', () => {
 describe('getLoadPath', () => {
   describe('in non-server platform', () => {
     const serverRequestOrigin = null;
-    const platform = 'non-server';
 
     describe('with relative path starting with "./"', () => {
       const path = './path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -63,7 +62,7 @@ describe('getLoadPath', () => {
       const path = '/path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -71,7 +70,7 @@ describe('getLoadPath', () => {
       const path = 'path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -79,7 +78,7 @@ describe('getLoadPath', () => {
       const path = 'http://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -87,20 +86,19 @@ describe('getLoadPath', () => {
       const path = 'https://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
       });
     });
   });
 
   describe('in server platform', () => {
     const serverRequestOrigin = 'http://server.com';
-    const platform = 'server';
 
     describe('with relative path starting with "./"', () => {
       const path = './path';
 
       it('should return the original path prepended with server request origin', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(
           'http://server.com/path'
         );
       });
@@ -110,7 +108,7 @@ describe('getLoadPath', () => {
       const path = '/path';
 
       it('should return the original path prepended with server request origin', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(
           'http://server.com/path'
         );
       });
@@ -120,7 +118,7 @@ describe('getLoadPath', () => {
       const path = 'path';
 
       it('should return the original path prepended with server request origin', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(
           'http://server.com/path'
         );
       });
@@ -130,7 +128,7 @@ describe('getLoadPath', () => {
       const path = 'http://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -138,7 +136,7 @@ describe('getLoadPath', () => {
       const path = 'https://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
       });
     });
   });

--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -5,7 +5,7 @@ import {
   TestRequest,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { i18nextGetHttpClient } from './i18next-init';
+import { getLoadPath, i18nextGetHttpClient } from './i18next-init';
 
 describe('i18nextGetHttpClient should return a http client that', () => {
   let httpMock: HttpTestingController;
@@ -43,5 +43,103 @@ describe('i18nextGetHttpClient should return a http client that', () => {
   it('forwards failure response to i18next callback', () => {
     req.flush('test error message', { status: 404, statusText: 'Not Found' });
     expect(testCallback).toHaveBeenCalledWith(null, { status: 404 });
+  });
+});
+
+describe('getLoadPath', () => {
+  describe('in non-server platform', () => {
+    const serverRequestHost = null;
+    const platform = 'non-server';
+
+    describe('with relative path starting with "./"', () => {
+      const path = './path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+      });
+    });
+
+    describe('with relative path starting with "/"', () => {
+      const path = '/path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+      });
+    });
+
+    describe('with relative path starting with ""', () => {
+      const path = 'path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+      });
+    });
+
+    describe('with absolute path starting with "http://"', () => {
+      const path = 'http://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+      });
+    });
+
+    describe('with absolute path starting with "https://"', () => {
+      const path = 'https://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+      });
+    });
+  });
+
+  describe('in server platform', () => {
+    const serverRequestHost = 'http://server.com';
+    const platform = 'server';
+
+    describe('with relative path starting with "./"', () => {
+      const path = './path';
+
+      it('should return the original path prepended with server request host', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(
+          'http://server.com/path'
+        );
+      });
+    });
+
+    describe('with relative path starting with "/"', () => {
+      const path = '/path';
+
+      it('should return the original path prepended with server request host', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(
+          'http://server.com/path'
+        );
+      });
+    });
+
+    describe('with relative path starting with ""', () => {
+      const path = 'path';
+
+      it('should return the original path prepended with server request host', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(
+          'http://server.com/path'
+        );
+      });
+    });
+
+    describe('with absolute path starting with "http://"', () => {
+      const path = 'http://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+      });
+    });
+
+    describe('with absolute path starting with "https://"', () => {
+      const path = 'https://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+      });
+    });
   });
 });

--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -48,14 +48,14 @@ describe('i18nextGetHttpClient should return a http client that', () => {
 
 describe('getLoadPath', () => {
   describe('in non-server platform', () => {
-    const serverRequestHost = null;
+    const serverRequestOrigin = null;
     const platform = 'non-server';
 
     describe('with relative path starting with "./"', () => {
       const path = './path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -63,7 +63,7 @@ describe('getLoadPath', () => {
       const path = '/path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -71,7 +71,7 @@ describe('getLoadPath', () => {
       const path = 'path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -79,7 +79,7 @@ describe('getLoadPath', () => {
       const path = 'http://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -87,20 +87,20 @@ describe('getLoadPath', () => {
       const path = 'https://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
       });
     });
   });
 
   describe('in server platform', () => {
-    const serverRequestHost = 'http://server.com';
+    const serverRequestOrigin = 'http://server.com';
     const platform = 'server';
 
     describe('with relative path starting with "./"', () => {
       const path = './path';
 
-      it('should return the original path prepended with server request host', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(
+      it('should return the original path prepended with server request origin', () => {
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(
           'http://server.com/path'
         );
       });
@@ -109,8 +109,8 @@ describe('getLoadPath', () => {
     describe('with relative path starting with "/"', () => {
       const path = '/path';
 
-      it('should return the original path prepended with server request host', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(
+      it('should return the original path prepended with server request origin', () => {
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(
           'http://server.com/path'
         );
       });
@@ -119,8 +119,8 @@ describe('getLoadPath', () => {
     describe('with relative path starting with ""', () => {
       const path = 'path';
 
-      it('should return the original path prepended with server request host', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(
+      it('should return the original path prepended with server request origin', () => {
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(
           'http://server.com/path'
         );
       });
@@ -130,7 +130,7 @@ describe('getLoadPath', () => {
       const path = 'http://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
       });
     });
 
@@ -138,7 +138,7 @@ describe('getLoadPath', () => {
       const path = 'https://path';
 
       it('should return the original path', () => {
-        expect(getLoadPath(path, platform, serverRequestHost)).toBe(path);
+        expect(getLoadPath(path, platform, serverRequestOrigin)).toBe(path);
       });
     });
   });

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -110,7 +110,7 @@ export function getLoadPath(
     if (path.startsWith('./')) {
       path = path.slice(2);
     }
-    const result = serverRequestHost + '/' + path;
+    const result = `${serverRequestHost}/${path}`;
     return result;
   }
   return path;

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -11,7 +11,7 @@ export function i18nextInit(
   languageService: LanguageService,
   httpClient: HttpClient,
   platform: string,
-  serverRequestHost: string
+  serverRequestOrigin: string
 ): () => Promise<any> {
   return () =>
     configInit.getStableConfig('i18n').then(config => {
@@ -28,7 +28,7 @@ export function i18nextInit(
         const loadPath = getLoadPath(
           config.i18n.backend.loadPath,
           platform,
-          serverRequestHost
+          serverRequestOrigin
         );
         const backend = {
           loadPath,
@@ -86,7 +86,7 @@ export function i18nextGetHttpClient(
 }
 
 /**
- * Resolves the relative path to the absolute one in SSR, using the server request host.
+ * Resolves the relative path to the absolute one in SSR, using the server request's origin.
  * It's needed, because Angular Universal doesn't support relative URLs in HttpClient. See Angular issues:
  * - https://github.com/angular/angular/issues/19224
  * - https://github.com/angular/universal/issues/858
@@ -94,14 +94,14 @@ export function i18nextGetHttpClient(
 export function getLoadPath(
   path: string = '',
   platform: string,
-  serverRequestHost: string = ''
+  serverRequestOrigin: string = ''
 ): string {
   if (!path) {
     return undefined;
   }
   if (
     isPlatformServer(platform) &&
-    serverRequestHost &&
+    serverRequestOrigin &&
     !path.match(/^http(s)?:\/\//)
   ) {
     if (path.startsWith('/')) {
@@ -110,7 +110,7 @@ export function getLoadPath(
     if (path.startsWith('./')) {
       path = path.slice(2);
     }
-    const result = `${serverRequestHost}/${path}`;
+    const result = `${serverRequestOrigin}/${path}`;
     return result;
   }
   return path;

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -1,4 +1,3 @@
-import { isPlatformServer } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import i18next from 'i18next';
 import i18nextXhrBackend from 'i18next-xhr-backend';
@@ -10,7 +9,6 @@ export function i18nextInit(
   configInit: ConfigInitializerService,
   languageService: LanguageService,
   httpClient: HttpClient,
-  platform: string,
   serverRequestOrigin: string
 ): () => Promise<any> {
   return () =>
@@ -27,7 +25,6 @@ export function i18nextInit(
         i18next.use(i18nextXhrBackend);
         const loadPath = getLoadPath(
           config.i18n.backend.loadPath,
-          platform,
           serverRequestOrigin
         );
         const backend = {
@@ -91,19 +88,11 @@ export function i18nextGetHttpClient(
  * - https://github.com/angular/angular/issues/19224
  * - https://github.com/angular/universal/issues/858
  */
-export function getLoadPath(
-  path: string = '',
-  platform: string,
-  serverRequestOrigin: string = ''
-): string {
+export function getLoadPath(path: string, serverRequestOrigin: string): string {
   if (!path) {
     return undefined;
   }
-  if (
-    isPlatformServer(platform) &&
-    serverRequestOrigin &&
-    !path.match(/^http(s)?:\/\//)
-  ) {
+  if (serverRequestOrigin && !path.match(/^http(s)?:\/\//)) {
     if (path.startsWith('/')) {
       path = path.slice(1);
     }

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -1,3 +1,4 @@
+import { isPlatformServer } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import i18next from 'i18next';
 import i18nextXhrBackend from 'i18next-xhr-backend';
@@ -8,7 +9,9 @@ import { TranslationResources } from '../translation-resources';
 export function i18nextInit(
   configInit: ConfigInitializerService,
   languageService: LanguageService,
-  httpClient: HttpClient
+  httpClient: HttpClient,
+  platform: string,
+  serverRequestHost: string
 ): () => Promise<any> {
   return () =>
     configInit.getStableConfig('i18n').then(config => {
@@ -22,8 +25,13 @@ export function i18nextInit(
       };
       if (config.i18n.backend) {
         i18next.use(i18nextXhrBackend);
+        const loadPath = getLoadPath(
+          config.i18n.backend.loadPath,
+          platform,
+          serverRequestHost
+        );
         const backend = {
-          loadPath: config.i18n.backend.loadPath || undefined,
+          loadPath,
           ajax: i18nextGetHttpClient(httpClient),
         };
         i18nextConfig = { ...i18nextConfig, backend };
@@ -75,4 +83,35 @@ export function i18nextGetHttpClient(
         error => callback(null, { status: error.status })
       );
   };
+}
+
+/**
+ * Resolves the relative path to the absolute one in SSR, using the server request host.
+ * It's needed, because Angular Universal doesn't support relative URLs in HttpClient. See Angular issues:
+ * - https://github.com/angular/angular/issues/19224
+ * - https://github.com/angular/universal/issues/858
+ */
+export function getLoadPath(
+  path: string = '',
+  platform: string,
+  serverRequestHost: string = ''
+): string {
+  if (!path) {
+    return undefined;
+  }
+  if (
+    isPlatformServer(platform) &&
+    serverRequestHost &&
+    !path.match(/^http(s)?:\/\//)
+  ) {
+    if (path.startsWith('/')) {
+      path = path.slice(1);
+    }
+    if (path.startsWith('./')) {
+      path = path.slice(2);
+    }
+    const result = serverRequestHost + '/' + path;
+    return result;
+  }
+  return path;
 }

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,14 +1,26 @@
 import { HttpClient } from '@angular/common/http';
-import { APP_INITIALIZER, Provider } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  Optional,
+  PLATFORM_ID,
+  Provider,
+} from '@angular/core';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
+import { SERVER_REQUEST_HOST } from '../../ssr/ssr.providers';
 import { i18nextInit } from './i18next-init';
 
 export const i18nextProviders: Provider[] = [
   {
     provide: APP_INITIALIZER,
     useFactory: i18nextInit,
-    deps: [ConfigInitializerService, LanguageService, HttpClient],
+    deps: [
+      ConfigInitializerService,
+      LanguageService,
+      HttpClient,
+      PLATFORM_ID,
+      [new Optional(), SERVER_REQUEST_HOST],
+    ],
     multi: true,
   },
 ];

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,10 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import {
-  APP_INITIALIZER,
-  Optional,
-  PLATFORM_ID,
-  Provider,
-} from '@angular/core';
+import { APP_INITIALIZER, Optional, Provider } from '@angular/core';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
@@ -18,7 +13,6 @@ export const i18nextProviders: Provider[] = [
       ConfigInitializerService,
       LanguageService,
       HttpClient,
-      PLATFORM_ID,
       [new Optional(), SERVER_REQUEST_ORIGIN],
     ],
     multi: true,

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
-import { SERVER_REQUEST_HOST } from '../../ssr/ssr.providers';
+import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
 import { i18nextInit } from './i18next-init';
 
 export const i18nextProviders: Provider[] = [
@@ -19,7 +19,7 @@ export const i18nextProviders: Provider[] = [
       LanguageService,
       HttpClient,
       PLATFORM_ID,
-      [new Optional(), SERVER_REQUEST_HOST],
+      [new Optional(), SERVER_REQUEST_ORIGIN],
     ],
     multi: true,
   },

--- a/projects/core/src/ssr/ng-express-engine-decorator.ts
+++ b/projects/core/src/ssr/ng-express-engine-decorator.ts
@@ -1,5 +1,5 @@
 import { NgModuleFactory, StaticProvider, Type } from '@angular/core';
-import { SERVER_REQUEST_HOST, SERVER_REQUEST_URL } from './ssr.providers';
+import { SERVER_REQUEST_ORIGIN, SERVER_REQUEST_URL } from './ssr.providers';
 
 /**
  * These are the allowed options for the engine
@@ -76,16 +76,16 @@ export function getServerRequestProviders(
       useValue: getRequestUrl(options.req),
     },
     {
-      provide: SERVER_REQUEST_HOST,
-      useValue: getRequestHost(options.req),
+      provide: SERVER_REQUEST_ORIGIN,
+      useValue: getRequestOrigin(options.req),
     },
   ];
 }
 
 function getRequestUrl(req: any): string {
-  return getRequestHost(req) + req.originalUrl;
+  return getRequestOrigin(req) + req.originalUrl;
 }
 
-function getRequestHost(req: any): string {
+function getRequestOrigin(req: any): string {
   return req.protocol + '://' + req.get('host');
 }

--- a/projects/core/src/ssr/ng-express-engine-decorator.ts
+++ b/projects/core/src/ssr/ng-express-engine-decorator.ts
@@ -1,5 +1,5 @@
 import { NgModuleFactory, StaticProvider, Type } from '@angular/core';
-import { SERVER_REQUEST_URL } from './ssr.providers';
+import { SERVER_REQUEST_HOST, SERVER_REQUEST_URL } from './ssr.providers';
 
 /**
  * These are the allowed options for the engine
@@ -75,9 +75,17 @@ export function getServerRequestProviders(
       provide: SERVER_REQUEST_URL,
       useValue: getRequestUrl(options.req),
     },
+    {
+      provide: SERVER_REQUEST_HOST,
+      useValue: getRequestHost(options.req),
+    },
   ];
 }
 
 function getRequestUrl(req: any): string {
-  return req.protocol + '://' + req.get('host') + req.originalUrl;
+  return getRequestHost(req) + req.originalUrl;
+}
+
+function getRequestHost(req: any): string {
+  return req.protocol + '://' + req.get('host');
 }

--- a/projects/core/src/ssr/ssr.providers.ts
+++ b/projects/core/src/ssr/ssr.providers.ts
@@ -10,6 +10,6 @@ export const SERVER_REQUEST_URL = new InjectionToken<string>(
 /**
  * The url of the server request host when running SSR
  * */
-export const SERVER_REQUEST_HOST = new InjectionToken<string>(
-  'SERVER_REQUEST_HOST'
+export const SERVER_REQUEST_ORIGIN = new InjectionToken<string>(
+  'SERVER_REQUEST_ORIGIN'
 );

--- a/projects/core/src/ssr/ssr.providers.ts
+++ b/projects/core/src/ssr/ssr.providers.ts
@@ -6,3 +6,10 @@ import { InjectionToken } from '@angular/core';
 export const SERVER_REQUEST_URL = new InjectionToken<string>(
   'SERVER_REQUEST_URL'
 );
+
+/**
+ * The url of the server request host when running SSR
+ * */
+export const SERVER_REQUEST_HOST = new InjectionToken<string>(
+  'SERVER_REQUEST_HOST'
+);


### PR DESCRIPTION
Angular Universal doesn't support using HttpClient with relative URLs, so translations from local JSONs could not be loaded.

Now, only in SSR, the server request host is prepended to the configured path for i18n JSONs.
closes GH-6307