### PR TITLE
fix: Page Slot component overwrites classes (6318)

### DIFF
--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.html
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.html
@@ -1,7 +1,7 @@
 <ng-template
   [cxOutlet]="position"
   [cxOutletContext]="{ components$: components$ }"
-  [cxSkipLink]="position$ | async"
+  [cxSkipLink]="position"
 >
   <ng-template
     *ngFor="let component of components$ | async"

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
@@ -26,9 +26,15 @@ import { IntersectionOptions } from '../../../layout/loading/intersection.model'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PageSlotComponent implements OnInit, OnDestroy {
-  // need to have this host binding at the top as it will override the entire class
-  @HostBinding('class') @Input() set position(position: string) {
+  /**
+   * The position is used to find the CMS page slot (and optional outlet)
+   * that is rendered in the PageSlotComponent. Furthermore, the position
+   * is added as a CSS class name to the host element.
+   */
+  @Input()
+  set position(position: string) {
     this.position$.next(position);
+    this.renderer.addClass(this.hostElement.nativeElement, position);
   }
   get position(): string {
     return this.position$.value;

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
@@ -21,7 +21,7 @@ import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { IntersectionOptions } from '../../../layout/loading/intersection.model';
 
 @Component({
-  selector: 'cx-page-slot',
+  selector: 'cx-page-slot,[cx-page-slot]',
   templateUrl: './page-slot.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
In 1.4 we accidentally introduced a breaking change, it's a very edge case though. 

fixes #6318