### PR TITLE
fix: Page Slot component overwrites classes (6318)

### DIFF
--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
@@ -1,5 +1,6 @@
-import { Renderer2, Type } from '@angular/core';
+import { Component, Renderer2, Type } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import {
   CmsConfig,
   CmsService,
@@ -69,6 +70,20 @@ const MockCmsConfig: CmsConfig = {
   },
 };
 
+@Component({
+  template: `
+    <cx-page-slot position="section" class="host classes"></cx-page-slot>
+  `,
+})
+export class MockHostComponent {}
+
+@Component({
+  template: `
+    <div cx-page-slot position="section" class="host classes"></div>
+  `,
+})
+export class MockHostWithDivComponent {}
+
 describe('PageSlotComponent', () => {
   let pageSlotComponent: PageSlotComponent;
   let fixture: ComponentFixture<PageSlotComponent>;
@@ -83,6 +98,8 @@ describe('PageSlotComponent', () => {
         PageSlotComponent,
         ComponentWrapperDirective,
         OutletDirective,
+        MockHostComponent,
+        MockHostWithDivComponent,
       ],
       providers: [
         Renderer2,
@@ -122,6 +139,42 @@ describe('PageSlotComponent', () => {
 
   it('should be created', () => {
     expect(pageSlotComponent).toBeTruthy();
+  });
+
+  describe('use as an attribute selector', () => {
+    let el: HTMLElement;
+    beforeEach(() => {
+      const compFixture = TestBed.createComponent(MockHostWithDivComponent);
+      compFixture.detectChanges();
+      el = compFixture.debugElement.query(By.css('[cx-page-slot]'))
+        .nativeElement;
+    });
+    it('should get a position class', () => {
+      expect(el.classList).toContain('host');
+    });
+
+    it('should keep existing classes', () => {
+      expect(el.classList).toContain('host');
+      expect(el.classList).toContain('classes');
+      expect(el.classList).toContain('section');
+    });
+  });
+
+  describe('use as an element selector', () => {
+    let el: HTMLElement;
+    beforeEach(() => {
+      const compFixture = TestBed.createComponent(MockHostComponent);
+      compFixture.detectChanges();
+      el = compFixture.debugElement.query(By.css('cx-page-slot')).nativeElement;
+    });
+    it('should get a position class', () => {
+      expect(el.classList).toContain('host');
+    });
+    it('should keep existing classes', () => {
+      expect(el.classList).toContain('host');
+      expect(el.classList).toContain('classes');
+      expect(el.classList).toContain('section');
+    });
   });
 
   describe('slot position class', () => {

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
@@ -26,9 +26,15 @@ import { IntersectionOptions } from '../../../layout/loading/intersection.model'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PageSlotComponent implements OnInit, OnDestroy {
-  // need to have this host binding at the top as it will override the entire class
-  @HostBinding('class') @Input() set position(position: string) {
+  /**
+   * The position is used to find the CMS page slot (and optional outlet)
+   * that is rendered in the PageSlotComponent. Furthermore, the position
+   * is added as a CSS class name to the host element.
+   */
+  @Input()
+  set position(position: string) {
     this.position$.next(position);
+    this.renderer.addClass(this.hostElement.nativeElement, position);
   }
   get position(): string {
     return this.position$.value;

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
@@ -21,7 +21,7 @@ import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { IntersectionOptions } from '../../../layout/loading/intersection.model';
 
 @Component({
-  selector: 'cx-page-slot',
+  selector: 'cx-page-slot,[cx-page-slot]',
   templateUrl: './page-slot.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
In 1.4 we accidentally introduced a breaking change, it's a very edge case though.

fixes #6318