### PR TITLE
chore: add missing Angular MIT license notices

### DIFF
--- a/projects/core/src/routing/services/url-matcher-factory.service.ts
+++ b/projects/core/src/routing/services/url-matcher-factory.service.ts
@@ -59,6 +59,15 @@ export class UrlMatcherFactoryService {
       segmentGroup: UrlSegmentGroup,
       route: Route
     ): UrlMatchResult | null => {
+      /**
+       * @license
+       * The MIT License
+       * Copyright (c) 2010-2019 Google LLC. http://angular.io/license
+       *
+       * See:
+       * - https://github.com/angular/angular/blob/6f5f481fdae03f1d8db36284b64c7b82d9519d85/packages/router/src/shared.ts#L121
+       */
+
       // use function's argument, not the `route.path`
       if (path === '') {
         if (

--- a/projects/core/src/util/glob-utils.ts
+++ b/projects/core/src/util/glob-utils.ts
@@ -1,3 +1,14 @@
+/**
+ * @license
+ * The MIT License
+ * Copyright (c) 2010-2019 Google LLC. http://angular.io/license
+ *
+ * See:
+ * - https://github.com/angular/angular/blob/6f5f481fdae03f1d8db36284b64c7b82d9519d85/packages/service-worker/config/src/glob.ts
+ * - https://github.com/angular/angular/blob/6f5f481fdae03f1d8db36284b64c7b82d9519d85/aio/tests/deployment/shared/helpers.ts#L17
+ * - https://github.com/angular/angular/blob/6f5f481fdae03f1d8db36284b64c7b82d9519d85/packages/service-worker/config/src/generator.ts#L86
+ */
+
 const QUESTION_MARK = '[^/]';
 const WILD_SINGLE = '[^/]*';
 const WILD_OPEN = '(?:.+\\/)?';
@@ -17,7 +28,6 @@ const TO_ESCAPE_LITERAL_QM = [
 
 /**
  * Converts the glob-like pattern into regex string.
- * See similar Angular code: https://github.com/angular/angular/blob/master/packages/service-worker/config/src/glob.ts#L27
  *
  * Patterns use a limited glob format:
  * `**` matches 0 or more path segments


### PR DESCRIPTION
The PR https://github.com/SAP/cloud-commerce-spartacus-storefront/pull/4250 contained some copies and modifications of Angular's code. Here we add missing MIT license noticies.