### PR TITLE
fix: loading translations from local JSON files when using SSR - for 1.4.x 

### DIFF
--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -5,7 +5,7 @@ import {
   TestRequest,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { i18nextGetHttpClient } from './i18next-init';
+import { getLoadPath, i18nextGetHttpClient } from './i18next-init';
 
 describe('i18nextGetHttpClient should return a http client that', () => {
   let httpMock: HttpTestingController;
@@ -43,5 +43,101 @@ describe('i18nextGetHttpClient should return a http client that', () => {
   it('forwards failure response to i18next callback', () => {
     req.flush('test error message', { status: 404, statusText: 'Not Found' });
     expect(testCallback).toHaveBeenCalledWith(null, { status: 404 });
+  });
+});
+
+describe('getLoadPath', () => {
+  describe('in non-server platform', () => {
+    const serverRequestOrigin = null;
+
+    describe('with relative path starting with "./"', () => {
+      const path = './path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
+      });
+    });
+
+    describe('with relative path starting with "/"', () => {
+      const path = '/path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
+      });
+    });
+
+    describe('with relative path starting with ""', () => {
+      const path = 'path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
+      });
+    });
+
+    describe('with absolute path starting with "http://"', () => {
+      const path = 'http://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
+      });
+    });
+
+    describe('with absolute path starting with "https://"', () => {
+      const path = 'https://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
+      });
+    });
+  });
+
+  describe('in server platform', () => {
+    const serverRequestOrigin = 'http://server.com';
+
+    describe('with relative path starting with "./"', () => {
+      const path = './path';
+
+      it('should return the original path prepended with server request origin', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(
+          'http://server.com/path'
+        );
+      });
+    });
+
+    describe('with relative path starting with "/"', () => {
+      const path = '/path';
+
+      it('should return the original path prepended with server request origin', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(
+          'http://server.com/path'
+        );
+      });
+    });
+
+    describe('with relative path starting with ""', () => {
+      const path = 'path';
+
+      it('should return the original path prepended with server request origin', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(
+          'http://server.com/path'
+        );
+      });
+    });
+
+    describe('with absolute path starting with "http://"', () => {
+      const path = 'http://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
+      });
+    });
+
+    describe('with absolute path starting with "https://"', () => {
+      const path = 'https://path';
+
+      it('should return the original path', () => {
+        expect(getLoadPath(path, serverRequestOrigin)).toBe(path);
+      });
+    });
   });
 });

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,14 +1,20 @@
 import { HttpClient } from '@angular/common/http';
-import { APP_INITIALIZER, Provider } from '@angular/core';
+import { APP_INITIALIZER, Optional, Provider } from '@angular/core';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
+import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
 import { i18nextInit } from './i18next-init';
 
 export const i18nextProviders: Provider[] = [
   {
     provide: APP_INITIALIZER,
     useFactory: i18nextInit,
-    deps: [ConfigInitializerService, LanguageService, HttpClient],
+    deps: [
+      ConfigInitializerService,
+      LanguageService,
+      HttpClient,
+      [new Optional(), SERVER_REQUEST_ORIGIN],
+    ],
     multi: true,
   },
 ];

--- a/projects/core/src/ssr/ng-express-engine-decorator.ts
+++ b/projects/core/src/ssr/ng-express-engine-decorator.ts
@@ -1,5 +1,5 @@
 import { NgModuleFactory, StaticProvider, Type } from '@angular/core';
-import { SERVER_REQUEST_URL } from './ssr.providers';
+import { SERVER_REQUEST_ORIGIN, SERVER_REQUEST_URL } from './ssr.providers';
 
 /**
  * These are the allowed options for the engine
@@ -75,9 +75,17 @@ export function getServerRequestProviders(
       provide: SERVER_REQUEST_URL,
       useValue: getRequestUrl(options.req),
     },
+    {
+      provide: SERVER_REQUEST_ORIGIN,
+      useValue: getRequestOrigin(options.req),
+    },
   ];
 }
 
 function getRequestUrl(req: any): string {
-  return req.protocol + '://' + req.get('host') + req.originalUrl;
+  return getRequestOrigin(req) + req.originalUrl;
+}
+
+function getRequestOrigin(req: any): string {
+  return req.protocol + '://' + req.get('host');
 }

--- a/projects/core/src/ssr/ssr.providers.ts
+++ b/projects/core/src/ssr/ssr.providers.ts
@@ -6,3 +6,10 @@ import { InjectionToken } from '@angular/core';
 export const SERVER_REQUEST_URL = new InjectionToken<string>(
   'SERVER_REQUEST_URL'
 );
+
+/**
+ * The url of the server request host when running SSR
+ * */
+export const SERVER_REQUEST_ORIGIN = new InjectionToken<string>(
+  'SERVER_REQUEST_ORIGIN'
+);


### PR DESCRIPTION
Angular Universal doesn't support using HttpClient with relative URLs, so translations from local JSONs could not be loaded. See Angular issues:
    angular/angular#19224
    angular/universal#858

Now, only in SSR, the server request's origin is prepended to the configured path for i18n JSONs.

closes GH-6307