### PR TITLE
feat: Support business driven facet top values

### DIFF
--- a/projects/core/src/model/product-search.model.ts
+++ b/projects/core/src/model/product-search.model.ts
@@ -31,9 +31,22 @@ export interface Facet {
   multiSelect?: boolean;
   name?: string;
   priority?: number;
-  topValues?: FacetValue[];
   values?: FacetValue[];
   visible?: boolean;
+
+  /**
+   * Indicates the top values that will be shown instantly. The top values can be
+   * controlled by business users per facet.
+   */
+  topValueCount: number;
+
+  /**
+   * The OCC backend has topValues with duplicated facet data.
+   * This is not used in the UI, but normalized in the `topValueCount` property.
+   *
+   * TODO: remove the `topValues` property from the UI model.
+   */
+  topValues?: FacetValue[];
 }
 
 export interface SpellingSuggestion {

--- a/projects/core/src/model/product-search.model.ts
+++ b/projects/core/src/model/product-search.model.ts
@@ -38,13 +38,13 @@ export interface Facet {
    * Indicates the top values that will be shown instantly. The top values can be
    * controlled by business users per facet.
    */
-  topValueCount: number;
+  topValueCount?: number;
 
   /**
    * The OCC backend has topValues with duplicated facet data.
    * This is not used in the UI, but normalized in the `topValueCount` property.
    *
-   * TODO: remove the `topValues` property from the UI model.
+   * TODO: once we implement a dedicated UI model, we should remove the `topValues`.
    */
   topValues?: FacetValue[];
 }

--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.spec.ts
@@ -13,6 +13,28 @@ class MockConverterService {
 
 const mockSource: Occ.ProductSearchPage = {
   products: [{ images: [] }, { images: [] }],
+  facets: [
+    {
+      name: 'facet-1',
+      values: [{ count: 1 }, { count: 2 }, { count: 3 }],
+      topValues: [{}, {}],
+    } as Occ.Facet,
+  ],
+};
+
+const mockPlpWithFacets: Occ.ProductSearchPage = {
+  products: [{ images: [] }, { images: [] }],
+  facets: [
+    {
+      name: 'facet-1',
+      values: [{ count: 1 }, { count: 2 }, { count: 3 }],
+      topValues: [{}, {}],
+    },
+    {
+      name: 'facet-2',
+      values: [{ count: 1 }, { count: 2 }, { count: 3 }],
+    },
+  ] as Occ.Facet[],
 };
 
 describe('OccProductSearchPageNormalizer', () => {
@@ -40,11 +62,29 @@ describe('OccProductSearchPageNormalizer', () => {
 
   it('should apply product image normalizer to products', () => {
     const converter = TestBed.get(ConverterService as Type<ConverterService>);
+
     const result = normalizer.convert(mockSource);
-    const expected = {
-      products: [{ images: ['images' as any] }, { images: ['images' as any] }],
-    } as any;
-    expect(result).toEqual(expected);
+    const expected = [
+      { images: ['images' as any] },
+      { images: ['images' as any] },
+    ] as any;
+    expect(result.products).toEqual(expected);
+    expect(converter.convert).toHaveBeenCalled();
+  });
+
+  it('should normalize top values', () => {
+    const converter = TestBed.get(ConverterService as Type<ConverterService>);
+    const result = normalizer.convert(mockPlpWithFacets);
+
+    expect(result.facets[0].topValueCount).toEqual(2);
+    expect(converter.convert).toHaveBeenCalled();
+  });
+
+  it('should fallback to default top values', () => {
+    const converter = TestBed.get(ConverterService as Type<ConverterService>);
+    const result = normalizer.convert(mockPlpWithFacets);
+
+    expect(result.facets[1].topValueCount).toEqual(6);
     expect(converter.convert).toHaveBeenCalled();
   });
 });

--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
@@ -1,16 +1,25 @@
-import { Occ } from '../../../occ-models/occ.models';
+import { Injectable } from '@angular/core';
+import {
+  Facet,
+  ProductSearchPage,
+} from '../../../../model/product-search.model';
+import { PRODUCT_NORMALIZER } from '../../../../product/connectors/product/converters';
 import {
   Converter,
   ConverterService,
 } from '../../../../util/converter.service';
-import { Injectable } from '@angular/core';
-import { PRODUCT_NORMALIZER } from '../../../../product/connectors/product/converters';
-import { ProductSearchPage } from '../../../../model/product-search.model';
+import { Occ } from '../../../occ-models/occ.models';
 
 @Injectable({ providedIn: 'root' })
 export class OccProductSearchPageNormalizer
   implements Converter<Occ.ProductSearchPage, ProductSearchPage> {
   constructor(private converterService: ConverterService) {}
+
+  /**
+   * Specifies the minimal number of top values in case
+   * non have been setup by the business.
+   */
+  protected DEFAULT_TOP_VALUES = 6;
 
   convert(
     source: Occ.ProductSearchPage,
@@ -20,11 +29,38 @@ export class OccProductSearchPageNormalizer
       ...target,
       ...(source as any),
     };
+    this.normalizeFacetValues(target);
     if (source.products) {
       target.products = source.products.map(product =>
         this.converterService.convert(product, PRODUCT_NORMALIZER)
       );
     }
     return target;
+  }
+
+  /**
+   *
+   * In case there are so-called `topValues` given for the facet values,
+   * we replace the facet values by the topValues, simple because the
+   * values are obsolete.
+   *
+   * `topValues` is a feature in the adaptive search which can limit a large
+   * amount of facet values to a small set (5 by default). As long as the backend
+   * provides all facet values AND topValues, we normalize the data to not bother
+   * the UI with this specific feature.
+   */
+  private normalizeFacetValues(target: ProductSearchPage): void {
+    if (target.facets) {
+      target.facets.map((facet: Facet) => {
+        if ((<any>facet).topValues) {
+          facet.topValueCount = (<any>facet).topValues.length;
+          // no need to keep the array of topValues, as they duplicate the data.
+          delete (<any>facet).topValues;
+        } else {
+          facet.topValueCount = this.DEFAULT_TOP_VALUES;
+        }
+        return facet;
+      });
+    }
   }
 }

--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
@@ -29,7 +29,7 @@ export class OccProductSearchPageNormalizer
       ...target,
       ...(source as any),
     };
-    this.normalizeFacetValues(target);
+    this.normalizeFacetValues(source, target);
     if (source.products) {
       target.products = source.products.map(product =>
         this.converterService.convert(product, PRODUCT_NORMALIZER)
@@ -41,25 +41,25 @@ export class OccProductSearchPageNormalizer
   /**
    *
    * In case there are so-called `topValues` given for the facet values,
-   * we replace the facet values by the topValues, simple because the
+   * we replace the facet values by the topValues, simply because the
    * values are obsolete.
    *
-   * `topValues` is a feature in the adaptive search which can limit a large
+   * `topValues` is a feature in Adaptive Search which can limit a large
    * amount of facet values to a small set (5 by default). As long as the backend
    * provides all facet values AND topValues, we normalize the data to not bother
    * the UI with this specific feature.
    */
-  private normalizeFacetValues(target: ProductSearchPage): void {
+  private normalizeFacetValues(
+    source: Occ.ProductSearchPage,
+    target: ProductSearchPage
+  ): void {
     if (target.facets) {
-      target.facets.map((facet: Facet) => {
-        if ((<any>facet).topValues) {
-          facet.topValueCount = (<any>facet).topValues.length;
-          // no need to keep the array of topValues, as they duplicate the data.
-          delete (<any>facet).topValues;
-        } else {
-          facet.topValueCount = this.DEFAULT_TOP_VALUES;
-        }
-        return facet;
+      target.facets = source.facets.map((facetSource: Facet) => {
+        const { topValues, ...facetTarget } = facetSource;
+        facetTarget.topValueCount = topValues
+          ? topValues.length
+          : this.DEFAULT_TOP_VALUES;
+        return facetTarget;
       });
     }
   }

--- a/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.html
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.html
@@ -84,7 +84,7 @@
                 (click)="showMore(facet.name)"
                 *ngIf="
                   !showAllPerFacetMap.get(facet.name) &&
-                  facet.values.length > minPerFacet
+                  facet.values.length > facet.topValueCount
                 "
               >
                 {{ 'productList.showMore' | cxTranslate }}

--- a/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.ts
@@ -98,7 +98,7 @@ export class ProductFacetNavigationComponent implements OnInit, OnDestroy {
     }
   }
 
-  getVisibleFacetValues(facet: Facet): any {
+  getVisibleFacetValues(facet: Facet): Facet[] {
     return facet.values.slice(
       0,
       this.showAllPerFacetMap.get(facet.name)

--- a/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.ts
@@ -25,7 +25,6 @@ export class ProductFacetNavigationComponent implements OnInit, OnDestroy {
 
   activeFacetValueCode: string;
   searchResult: ProductSearchPage;
-  minPerFacet = 6;
   showAllPerFacetMap: Map<String, boolean>;
   protected queryCodec: HttpUrlEncodingCodec;
   private collapsedFacets = new Set<string>();
@@ -99,12 +98,12 @@ export class ProductFacetNavigationComponent implements OnInit, OnDestroy {
     }
   }
 
-  getVisibleFacetValues(facet): any {
+  getVisibleFacetValues(facet: Facet): any {
     return facet.values.slice(
       0,
       this.showAllPerFacetMap.get(facet.name)
         ? facet.values.length
-        : this.minPerFacet
+        : facet.topValueCount
     );
   }
 


### PR DESCRIPTION
The search business tools allow for so-called topValues configuration, a number that indicates the direct visible values of a facet. So far, this number was only hard-coded in Spartacus. With this feature, the business user can customise the number per facet.

The topValues are normalised from the backend to the UI model. A default number (6) is used in case there are no top values given. 

closes #5692 