### PR TITLE
feat: Remove useless facets from the product result response

### DIFF
--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.spec.ts
@@ -13,6 +13,42 @@ class MockConverterService {
 
 const mockSource: Occ.ProductSearchPage = {
   products: [{ images: [] }, { images: [] }],
+  facets: [
+    {
+      name: 'facet-1',
+      values: [{ count: 1 }, { count: 2 }, { count: 3 }],
+      topValues: [{}, {}],
+    } as Occ.Facet,
+  ],
+};
+
+const mockPlpWithUselessFacets: Occ.ProductSearchPage = {
+  pagination: {
+    totalResults: 2,
+  },
+  facets: [
+    {
+      name: 'useless-facet',
+      values: [{ count: 2 }, { count: 2 }],
+    },
+    {
+      name: 'useful-facet',
+      values: [{ count: 1 }, { count: 2 }, { count: 1 }],
+    },
+  ] as Occ.Facet[],
+};
+
+const mockPlpWithoutPagination: Occ.ProductSearchPage = {
+  facets: [
+    {
+      name: 'useless-facet',
+      values: [{ count: 2 }, { count: 2 }],
+    },
+    {
+      name: 'useful-facet',
+      values: [{ count: 1 }, { count: 2 }, { count: 1 }],
+    },
+  ] as Occ.Facet[],
 };
 
 describe('OccProductSearchPageNormalizer', () => {
@@ -41,10 +77,24 @@ describe('OccProductSearchPageNormalizer', () => {
   it('should apply product image normalizer to products', () => {
     const converter = TestBed.get(ConverterService as Type<ConverterService>);
     const result = normalizer.convert(mockSource);
-    const expected = {
-      products: [{ images: ['images' as any] }, { images: ['images' as any] }],
-    } as any;
-    expect(result).toEqual(expected);
+    const expected = [
+      { images: ['images' as any] },
+      { images: ['images' as any] },
+    ] as any;
+    expect(result.products).toEqual(expected);
     expect(converter.convert).toHaveBeenCalled();
+  });
+
+  describe('normalize facet value count', () => {
+    it('should remove useles facet from facet list', () => {
+      const result = normalizer.convert(mockPlpWithUselessFacets);
+      expect(result.facets.length).toEqual(1);
+      expect(result.facets[0].name).toEqual('useful-facet');
+    });
+
+    it('should not remove useles facet facet list if pagination is not used', () => {
+      const result = normalizer.convert(mockPlpWithoutPagination);
+      expect(result.facets.length).toEqual(2);
+    });
   });
 });

--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
@@ -1,11 +1,11 @@
-import { Occ } from '../../../occ-models/occ.models';
+import { Injectable } from '@angular/core';
+import { ProductSearchPage } from '../../../../model/product-search.model';
+import { PRODUCT_NORMALIZER } from '../../../../product/connectors/product/converters';
 import {
   Converter,
   ConverterService,
 } from '../../../../util/converter.service';
-import { Injectable } from '@angular/core';
-import { PRODUCT_NORMALIZER } from '../../../../product/connectors/product/converters';
-import { ProductSearchPage } from '../../../../model/product-search.model';
+import { Occ } from '../../../occ-models/occ.models';
 
 @Injectable({ providedIn: 'root' })
 export class OccProductSearchPageNormalizer
@@ -20,11 +20,40 @@ export class OccProductSearchPageNormalizer
       ...target,
       ...(source as any),
     };
+    this.normalizeUselessFacets(target);
     if (source.products) {
       target.products = source.products.map(product =>
         this.converterService.convert(product, PRODUCT_NORMALIZER)
       );
     }
     return target;
+  }
+
+  /**
+   * The (current) backend returns facets with values that do not contribute
+   * to the facet navigation much, as the number in the result list will not get
+   * affected when they got applied. A ticket has been created to fix this
+   * behaviour, see https://jira.hybris.com/browse/CS-427.
+   *
+   * As long as this is not in place, we manually filter the facet from the list;
+   * any facet that does not have a count < the total results will be dropped from
+   * the facets.
+   */
+  private normalizeUselessFacets(target: ProductSearchPage): void {
+    target.facets = [].concat(
+      target.facets.filter(facet => {
+        return (
+          !target.pagination ||
+          !target.pagination.totalResults ||
+          ((!facet.hasOwnProperty('visible') || facet.visible) &&
+            facet.values &&
+            facet.values.find(value => {
+              return (
+                value.selected || value.count < target.pagination.totalResults
+              );
+            }))
+        );
+      })
+    );
   }
 }

--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
@@ -29,8 +29,8 @@ export class OccProductSearchPageNormalizer
       ...target,
       ...(source as any),
     };
-    this.normalizeUselessFacets(target);
-    this.normalizeFacetValues(source, target);
+
+    this.normalizeFacets(target);
     if (source.products) {
       target.products = source.products.map(product =>
         this.converterService.convert(product, PRODUCT_NORMALIZER)
@@ -39,6 +39,10 @@ export class OccProductSearchPageNormalizer
     return target;
   }
 
+  private normalizeFacets(target: ProductSearchPage): void {
+    this.normalizeFacetValues(target);
+    this.normalizeUselessFacets(target);
+  }
   /**
    * The (current) backend returns facets with values that do not contribute
    * to the facet navigation much, as the number in the result list will not get
@@ -49,21 +53,19 @@ export class OccProductSearchPageNormalizer
    * the facets.
    */
   private normalizeUselessFacets(target: ProductSearchPage): void {
-    target.facets = [].concat(
-      target.facets.filter(facet => {
-        return (
-          !target.pagination ||
-          !target.pagination.totalResults ||
-          ((!facet.hasOwnProperty('visible') || facet.visible) &&
-            facet.values &&
-            facet.values.find(value => {
-              return (
-                value.selected || value.count < target.pagination.totalResults
-              );
-            }))
-        );
-      })
-    );
+    target.facets = target.facets.filter(facet => {
+      return (
+        !target.pagination ||
+        !target.pagination.totalResults ||
+        ((!facet.hasOwnProperty('visible') || facet.visible) &&
+          facet.values &&
+          facet.values.find(value => {
+            return (
+              value.selected || value.count < target.pagination.totalResults
+            );
+          }))
+      );
+    });
   }
 
   /*
@@ -75,12 +77,9 @@ export class OccProductSearchPageNormalizer
    * provides all facet values AND topValues, we normalize the data to not bother
    * the UI with this specific feature.
    */
-  private normalizeFacetValues(
-    source: Occ.ProductSearchPage,
-    target: ProductSearchPage
-  ): void {
+  private normalizeFacetValues(target: ProductSearchPage): void {
     if (target.facets) {
-      target.facets = source.facets.map((facetSource: Facet) => {
+      target.facets = target.facets.map((facetSource: Facet) => {
         const { topValues, ...facetTarget } = facetSource;
         facetTarget.topValueCount = topValues
           ? topValues.length


### PR DESCRIPTION
If a facet contains values that cannot reduce the size of the product result list, it will be removed from the facet list. This is expected from the backend, but as long as this is not implemented, we keep the facet list clean. 

closes #6599 