### PR TITLE
feat: use a clean DOM and CSS for PLP slots

### DIFF
--- a/projects/storefrontlib/src/recipes/config/b2c-layout-config.ts
+++ b/projects/storefrontlib/src/recipes/config/b2c-layout-config.ts
@@ -53,16 +53,16 @@ export const b2cLayoutConfig: LayoutConfig = {
       slots: ['Section1', 'Section2', 'Section3'],
     },
     ProductListPageTemplate: {
-      slots: ['ProductListSlot', 'ProductLeftRefinements'],
+      slots: ['ProductLeftRefinements', 'ProductListSlot'],
     },
     ProductGridPageTemplate: {
-      slots: ['ProductGridSlot', 'ProductLeftRefinements'],
+      slots: ['ProductLeftRefinements', 'ProductGridSlot'],
     },
     SearchResultsListPageTemplate: {
       slots: [
         'Section2',
-        'SearchResultsListSlot',
         'ProductLeftRefinements',
+        'SearchResultsListSlot',
         'Section4',
       ],
     },

--- a/projects/storefrontstyles/scss/layout/page-templates/_product-list.scss
+++ b/projects/storefrontstyles/scss/layout/page-templates/_product-list.scss
@@ -7,7 +7,6 @@
     flex-direction: column;
   }
   .ProductLeftRefinements {
-    order: 1;
     max-width: 25%;
     padding: 60px 15px 15px 15px;
 
@@ -18,7 +17,6 @@
   }
   .ProductListSlot,
   .ProductGridSlot {
-    order: 2;
     max-width: 75%;
 
     @include media-breakpoint-down(md) {

--- a/projects/storefrontstyles/scss/layout/page-templates/_search-results-list.scss
+++ b/projects/storefrontstyles/scss/layout/page-templates/_search-results-list.scss
@@ -9,7 +9,6 @@
     flex-direction: column;
   }
   .ProductLeftRefinements {
-    order: 1;
     max-width: 25%;
     padding: 60px 15px 15px 15px;
 
@@ -19,7 +18,6 @@
     }
   }
   .SearchResultsListSlot {
-    order: 2;
     max-width: 75%;
 
     @include media-breakpoint-down(md) {
@@ -32,6 +30,5 @@
   }
   .Section4 {
     padding: 0 1rem;
-    order: 3;
   }
 }


### PR DESCRIPTION
The various slots on listing pages (category and search) have been ordered with a combination of a layout configuration and order rules in CSS (flexbox) in release 1. This has not been done for a good reason, and it is leading to accessibility issues on the listing page. 

closes #6615 


BREAKING CHANGE:
- the b2cLayoutConfig will change, which will produced a change in the DOM for the category and search pages
- the CSS layout for the category and search pages will no longer use specific "order" for the layout.